### PR TITLE
Feat: Factory v2.1 (multiple implementations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the [documentation](https://curve.readthedocs.io/factory-overview.html) for 
 ### Dependencies
 
 * [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
-* [brownie](https://github.com/eth-brownie/brownie) - tested with version [1.13.0](https://github.com/eth-brownie/brownie/releases/tag/v1.13.0)
+* [brownie](https://github.com/eth-brownie/brownie) - tested with version [1.14.6](https://github.com/eth-brownie/brownie/releases/tag/v1.14.6)
 * [brownie-token-tester](https://github.com/iamdefinitelyahuman/brownie-token-tester)
 * [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.12.1](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.12.1)
 

--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -502,6 +502,23 @@ def deploy_metapool(
 
 
 @external
+def deploy_plain_pool(
+    _name: String[32],
+    _symbol: String[10],
+    _coins: address[4],
+    _A: uint256,
+    _fee: uint256,
+    _implementation_idx: uint256 = 0,
+) -> address:
+    # iterate _coins to determine n_coins and check against self.base_pool_assets
+    # deploy pool and store data
+
+    # need to expand getters for not-metapools!
+    return ZERO_ADDRESS
+
+
+
+@external
 def add_existing_pools(_pools: address[N_POOLS], _base_pool: address, _implementation: address) -> bool:
     """
     @notice Add existing factory pools to this factory

--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -339,10 +339,9 @@ def get_admin_balances(_pool: address) -> uint256[MAX_PLAIN_COINS]:
     n_coins: uint256 = self.pool_data[_pool].n_coins
     admin_balances: uint256[MAX_PLAIN_COINS] = empty(uint256[MAX_PLAIN_COINS])
     for i in range(MAX_PLAIN_COINS):
-        if i < n_coins:
-            admin_balances[i] = CurvePool(_pool).admin_balances(i)
-        else:
-            admin_balances[i] = 0
+        if i == n_coins:
+            break
+        admin_balances[i] = CurvePool(_pool).admin_balances(i)
     return admin_balances
 
 

--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -79,7 +79,7 @@ event BasePoolAdded:
     base_pool: address
 
 event PlainPoolDeployed:
-    coins: address[4]
+    coins: address[MAX_PLAIN_COINS]
     A: uint256
     fee: uint256
     deployer: address
@@ -168,7 +168,7 @@ def get_n_coins(_pool: address) -> (uint256, uint256):
 
 @view
 @external
-def get_coins(_pool: address) -> address[4]:
+def get_coins(_pool: address) -> address[MAX_PLAIN_COINS]:
     """
     @notice Get the coins within a pool
     @param _pool Pool address
@@ -537,13 +537,13 @@ def deploy_metapool(
 def deploy_plain_pool(
     _name: String[32],
     _symbol: String[10],
-    _coins: address[4],
+    _coins: address[MAX_PLAIN_COINS],
     _A: uint256,
     _fee: uint256,
     _implementation_idx: uint256 = 0,
 ) -> address:
     n_coins: uint256 = 0
-    decimals: uint256[4] = empty(uint256[4])
+    decimals: uint256[MAX_PLAIN_COINS] = empty(uint256[MAX_PLAIN_COINS])
     for coin in _coins:
         assert self.base_pool_assets[coin] == False  # dev: pool should be deployed as metapool
         assert self.registered_coins[coin] == False # dev: pool cannot contain duplicate coins
@@ -566,7 +566,7 @@ def deploy_plain_pool(
     self.pool_data[pool].decimals = decimals
     self.pool_data[pool].base_pool = ZERO_ADDRESS
     self.pool_data[pool].implementation = implementation
-    for i in range(4):
+    for i in range(MAX_PLAIN_COINS):
         if _coins[i] == ZERO_ADDRESS:
             break
         self.pool_data[pool].coins[i] = _coins[i]

--- a/contracts/MetaImplementationBTC.vy
+++ b/contracts/MetaImplementationBTC.vy
@@ -78,22 +78,6 @@ event RemoveLiquidityImbalance:
     invariant: uint256
     token_supply: uint256
 
-event CommitNewAdmin:
-    deadline: indexed(uint256)
-    admin: indexed(address)
-
-event NewAdmin:
-    admin: indexed(address)
-
-event CommitNewFee:
-    deadline: indexed(uint256)
-    fee: uint256
-    admin_fee: uint256
-
-event NewFee:
-    fee: uint256
-    admin_fee: uint256
-
 event RampA:
     old_A: uint256
     new_A: uint256

--- a/contracts/MetaImplementationBTC.vy
+++ b/contracts/MetaImplementationBTC.vy
@@ -24,7 +24,7 @@ interface Curve:
     def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
 
 interface Factory:
-    def convert_fees() -> bool: nonpayable
+    def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
 
 
@@ -1107,7 +1107,7 @@ def withdraw_admin_fees():
     amount: uint256 = ERC20(coin).balanceOf(self) - self.balances[0]
     if amount > 0:
         ERC20(coin).transfer(factory, amount)
-        Factory(factory).convert_fees()
+        Factory(factory).convert_metapool_fees()
 
     # transfer coin 1 to the receiver
     coin = self.coins[1]

--- a/contracts/MetaImplementationRebaseBTC.vy
+++ b/contracts/MetaImplementationRebaseBTC.vy
@@ -78,22 +78,6 @@ event RemoveLiquidityImbalance:
     invariant: uint256
     token_supply: uint256
 
-event CommitNewAdmin:
-    deadline: indexed(uint256)
-    admin: indexed(address)
-
-event NewAdmin:
-    admin: indexed(address)
-
-event CommitNewFee:
-    deadline: indexed(uint256)
-    fee: uint256
-    admin_fee: uint256
-
-event NewFee:
-    fee: uint256
-    admin_fee: uint256
-
 event RampA:
     old_A: uint256
     new_A: uint256

--- a/contracts/MetaImplementationRebaseBTC.vy
+++ b/contracts/MetaImplementationRebaseBTC.vy
@@ -24,7 +24,7 @@ interface Curve:
     def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
 
 interface Factory:
-    def convert_fees() -> bool: nonpayable
+    def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
 
 
@@ -1109,7 +1109,7 @@ def withdraw_admin_fees():
     amount: uint256 = self.admin_balances[0]
     if amount > 0:
         ERC20(coin).transfer(factory, amount)
-        Factory(factory).convert_fees()
+        Factory(factory).convert_metapool_fees()
         self.admin_balances[0] = 0
 
     # transfer coin 1 to the receiver

--- a/contracts/MetaImplementationRebaseUSD.vy
+++ b/contracts/MetaImplementationRebaseUSD.vy
@@ -78,22 +78,6 @@ event RemoveLiquidityImbalance:
     invariant: uint256
     token_supply: uint256
 
-event CommitNewAdmin:
-    deadline: indexed(uint256)
-    admin: indexed(address)
-
-event NewAdmin:
-    admin: indexed(address)
-
-event CommitNewFee:
-    deadline: indexed(uint256)
-    fee: uint256
-    admin_fee: uint256
-
-event NewFee:
-    fee: uint256
-    admin_fee: uint256
-
 event RampA:
     old_A: uint256
     new_A: uint256

--- a/contracts/MetaImplementationRebaseUSD.vy
+++ b/contracts/MetaImplementationRebaseUSD.vy
@@ -24,7 +24,7 @@ interface Curve:
     def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
 
 interface Factory:
-    def convert_fees() -> bool: nonpayable
+    def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
 
 
@@ -1114,7 +1114,7 @@ def withdraw_admin_fees():
     amount: uint256 = self.admin_balances[0]
     if amount > 0:
         ERC20(coin).transfer(factory, amount)
-        Factory(factory).convert_fees()
+        Factory(factory).convert_metapool_fees()
         self.admin_balances[0] = 0
 
     # transfer coin 1 to the receiver

--- a/contracts/MetaImplementationUSD.vy
+++ b/contracts/MetaImplementationUSD.vy
@@ -78,22 +78,6 @@ event RemoveLiquidityImbalance:
     invariant: uint256
     token_supply: uint256
 
-event CommitNewAdmin:
-    deadline: indexed(uint256)
-    admin: indexed(address)
-
-event NewAdmin:
-    admin: indexed(address)
-
-event CommitNewFee:
-    deadline: indexed(uint256)
-    fee: uint256
-    admin_fee: uint256
-
-event NewFee:
-    fee: uint256
-    admin_fee: uint256
-
 event RampA:
     old_A: uint256
     new_A: uint256

--- a/contracts/MetaImplementationUSD.vy
+++ b/contracts/MetaImplementationUSD.vy
@@ -24,7 +24,7 @@ interface Curve:
     def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
 
 interface Factory:
-    def convert_fees() -> bool: nonpayable
+    def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
 
 
@@ -1113,7 +1113,7 @@ def withdraw_admin_fees():
     amount: uint256 = ERC20(coin).balanceOf(self) - self.balances[0]
     if amount > 0:
         ERC20(coin).transfer(factory, amount)
-        Factory(factory).convert_fees()
+        Factory(factory).convert_metapool_fees()
 
     # transfer coin 1 to the receiver
     coin = self.coins[1]

--- a/contracts/PlainPoolImplementation.vy
+++ b/contracts/PlainPoolImplementation.vy
@@ -949,5 +949,16 @@ def admin_balances(i: uint256) -> uint256:
 
 @external
 def withdraw_admin_fees():
-    # Do some fee burning magic through factory
     factory: address = self.factory
+    receiver: address = Factory(factory).fee_receiver(self)
+    assert receiver != ZERO_ADDRESS  # dev: receiver is not set
+
+    fees: uint256 = 0
+    for i in range(N_COINS):
+        coin: address = self.coins[i]
+        if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            fees = self.balance - self.balances[i]
+            raw_call(receiver, b"", value=fees)
+        else:
+            fees = ERC20(coin).balanceOf(self) - self.balances[i]
+            ERC20(coin).transfer(receiver, fees)

--- a/contracts/PlainPoolImplementation.vy
+++ b/contracts/PlainPoolImplementation.vy
@@ -116,8 +116,8 @@ def __init__():
 def initialize(
     _name: String[32],
     _symbol: String[10],
-    _coins: address[N_COINS],
-    _decimals: uint256[N_COINS],
+    _coins: address[4],
+    _decimals: uint256[4],
     _A: uint256,
     _fee: uint256,
     _admin: address
@@ -140,15 +140,15 @@ def initialize(
     assert self.fee == 0
 
     for i in range(N_COINS):
-        if _coins[i] != ZERO_ADDRESS:
+        if _coins[i] == ZERO_ADDRESS:
             break
         if _coins[i] == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
             assert i == 0  # dev: ETH must be at index 0
         # things break if a token has >18 decimals
         assert _decimals[i] < 19
         self.rate_multipliers[i] = 10 ** (36 - _decimals[i])
+        self.coins[i] = _coins[i]
 
-    self.coins = _coins
     self.initial_A = _A * A_PRECISION
     self.future_A = _A * A_PRECISION
     self.fee = _fee

--- a/contracts/PlainPoolImplementation.vy
+++ b/contracts/PlainPoolImplementation.vy
@@ -1,0 +1,953 @@
+# @version 0.2.12
+"""
+@title StableSwap
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2020 - all rights reserved
+@notice Minimal pool implementation with no lending
+@dev This contract is only a template, pool-specific constants
+     must be set prior to compiling
+"""
+
+from vyper.interfaces import ERC20
+
+interface Factory:
+    def convert_fees() -> bool: nonpayable
+    def fee_receiver(_base_pool: address) -> address: view
+
+
+event Transfer:
+    sender: indexed(address)
+    receiver: indexed(address)
+    value: uint256
+
+event Approval:
+    owner: indexed(address)
+    spender: indexed(address)
+    value: uint256
+
+event TokenExchange:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event AddLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RemoveLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    token_supply: uint256
+
+event RemoveLiquidityOne:
+    provider: indexed(address)
+    token_amount: uint256
+    coin_amount: uint256
+    token_supply: uint256
+
+event RemoveLiquidityImbalance:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RampA:
+    old_A: uint256
+    new_A: uint256
+    initial_time: uint256
+    future_time: uint256
+
+event StopRampA:
+    A: uint256
+    t: uint256
+
+
+N_COINS: constant(int128) = 2
+PRECISION: constant(uint256) = 10 ** 18
+
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+ADMIN_FEE: constant(uint256) = 5000000000
+
+A_PRECISION: constant(uint256) = 100
+MAX_A: constant(uint256) = 10 ** 6
+MAX_A_CHANGE: constant(uint256) = 10
+MIN_RAMP_TIME: constant(uint256) = 86400
+
+admin: public(address)
+factory: address
+
+coins: public(address[N_COINS])
+balances: public(uint256[N_COINS])
+fee: public(uint256)  # fee * 1e10
+
+previous_balances: uint256[N_COINS]
+price_cumulative_last: uint256[N_COINS]
+block_timestamp_last: public(uint256)
+
+initial_A: public(uint256)
+future_A: public(uint256)
+initial_A_time: public(uint256)
+future_A_time: public(uint256)
+
+rate_multipliers: uint256[N_COINS]
+
+name: public(String[64])
+symbol: public(String[32])
+
+balanceOf: public(HashMap[address, uint256])
+allowance: public(HashMap[address, HashMap[address, uint256]])
+totalSupply: public(uint256)
+
+
+@external
+def __init__():
+    # we do this to prevent the implementation contract from being used as a pool
+    self.fee = 31337
+
+
+@external
+def initialize(
+    _name: String[32],
+    _symbol: String[10],
+    _coins: address[N_COINS],
+    _decimals: uint256[N_COINS],
+    _A: uint256,
+    _fee: uint256,
+    _admin: address
+):
+    """
+    @notice Contract constructor
+    @param _name Name of the new pool
+    @param _symbol Token symbol
+    @param _coins List of all ERC20 conract addresses of coins
+    @param _decimals List of number of decimals in coins
+    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _fee Fee to charge for exchanges
+    @param _admin Admin address
+    """
+
+    # fee must be between 0.04% and 1%
+    assert _fee >= 4000000
+    assert _fee <= 100000000
+    # check if fee was already set to prevent initializing contract twice
+    assert self.fee == 0
+
+    for i in range(N_COINS):
+        if _coins[i] != ZERO_ADDRESS:
+            break
+        if _coins[i] == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            assert i == 0  # dev: ETH must be at index 0
+        # things break if a token has >18 decimals
+        assert _decimals[i] < 19
+        self.rate_multipliers[i] = 10 ** (36 - _decimals[i])
+
+    self.coins = _coins
+    self.initial_A = _A * A_PRECISION
+    self.future_A = _A * A_PRECISION
+    self.fee = _fee
+    self.admin = _admin
+    self.factory = msg.sender
+
+    self.name = concat("Curve.fi Factory Plain Pool: ", _name)
+    self.symbol = concat(_symbol, "-f")
+
+### ERC20 Functionality ###
+
+@view
+@external
+def decimals() -> uint256:
+    """
+    @notice Get the number of decimals for this token
+    @dev Implemented as a view method to reduce gas costs
+    @return uint256 decimal places
+    """
+    return 18
+
+
+@internal
+def _transfer(_from: address, _to: address, _value: uint256):
+    # # NOTE: vyper does not allow underflows
+    # #       so the following subtraction would revert on insufficient balance
+    self.balanceOf[_from] -= _value
+    self.balanceOf[_to] += _value
+
+    log Transfer(_from, _to, _value)
+
+
+@external
+def transfer(_to : address, _value : uint256) -> bool:
+    """
+    @dev Transfer token for a specified address
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    self._transfer(msg.sender, _to, _value)
+    return True
+
+
+@external
+def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    """
+     @dev Transfer tokens from one address to another.
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    self._transfer(_from, _to, _value)
+
+    _allowance: uint256 = self.allowance[_from][msg.sender]
+    if _allowance != MAX_UINT256:
+        self.allowance[_from][msg.sender] = _allowance - _value
+
+    return True
+
+
+@external
+def approve(_spender : address, _value : uint256) -> bool:
+    """
+    @notice Approve the passed address to transfer the specified amount of
+            tokens on behalf of msg.sender
+    @dev Beware that changing an allowance via this method brings the risk that
+         someone may use both the old and new allowance by unfortunate transaction
+         ordering: https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will transfer the funds
+    @param _value The amount of tokens that may be transferred
+    @return bool success
+    """
+    self.allowance[msg.sender][_spender] = _value
+
+    log Approval(msg.sender, _spender, _value)
+    return True
+
+
+### StableSwap Functionality ###
+
+@view
+@external
+def get_previous_balances() -> uint256[N_COINS]:
+    return self.previous_balances
+
+
+@view
+@external
+def get_balances() -> uint256[N_COINS]:
+    return self.balances
+
+
+@view
+@external
+def get_price_cumulative_last() -> uint256[N_COINS]:
+    return self.price_cumulative_last
+
+
+@view
+@internal
+def _A() -> uint256:
+    """
+    Handle ramping A up or down
+    """
+    t1: uint256 = self.future_A_time
+    A1: uint256 = self.future_A
+
+    if block.timestamp < t1:
+        A0: uint256 = self.initial_A
+        t0: uint256 = self.initial_A_time
+        # Expressions in uint256 cannot have negative numbers, thus "if"
+        if A1 > A0:
+            return A0 + (A1 - A0) * (block.timestamp - t0) / (t1 - t0)
+        else:
+            return A0 - (A0 - A1) * (block.timestamp - t0) / (t1 - t0)
+
+    else:  # when t1 == 0 or block.timestamp >= t1
+        return A1
+
+
+@internal
+def _update():
+    """
+    Commits pre-change balances for the previous block
+    Can be used to compare against current values for flash loan checks
+    """
+    elapsed_time: uint256 = block.timestamp - self.block_timestamp_last
+    if elapsed_time > 0:
+        for i in range(N_COINS):
+            _balance: uint256 = self.balances[i]
+            self.price_cumulative_last[i] += _balance * elapsed_time
+            self.previous_balances[i] = _balance
+        self.block_timestamp_last = block.timestamp
+
+
+@view
+@external
+def admin_fee() -> uint256:
+    return ADMIN_FEE
+
+
+@view
+@external
+def A() -> uint256:
+    return self._A() / A_PRECISION
+
+
+@view
+@external
+def A_precise() -> uint256:
+    return self._A()
+
+
+@view
+@internal
+def _xp(_rates: uint256[N_COINS]) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        result[i] = _rates[i] * self.balances[i] / PRECISION
+    return result
+
+
+@pure
+@internal
+def _xp_mem(_rates: uint256[N_COINS], _balances: uint256[N_COINS]) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        result[i] = _rates[i] * _balances[i] / PRECISION
+    return result
+
+
+@pure
+@internal
+def _get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
+    """
+    D invariant calculation in non-overflowing integer operations
+    iteratively
+
+    A * sum(x_i) * n**n + D = A * D * n**n + D**(n+1) / (n**n * prod(x_i))
+
+    Converging solution:
+    D[j+1] = (A * n**n * sum(x_i) - D[j]**(n+1) / (n**n prod(x_i))) / (A * n**n - 1)
+    """
+    S: uint256 = 0
+    Dprev: uint256 = 0
+
+    for _x in _xp:
+        S += _x
+    if S == 0:
+        return 0
+
+    D: uint256 = S
+    Ann: uint256 = _amp * N_COINS
+    for _i in range(255):
+        D_P: uint256 = D
+        for _x in _xp:
+            D_P = D_P * D / (_x * N_COINS)  # If division by 0, this will be borked: only withdrawal will work. And that is good
+        Dprev = D
+        D = (Ann * S / A_PRECISION + D_P * N_COINS) * D / ((Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P)
+        # Equality with the precision of 1
+        if D > Dprev:
+            if D - Dprev <= 1:
+                return D
+        else:
+            if Dprev - D <= 1:
+                return D
+    # convergence typically occurs in 4 rounds or less, this should be unreachable!
+    # if it does happen the pool is borked and LPs can withdraw via `remove_liquidity`
+    raise
+
+
+@view
+@internal
+def _get_D_mem(_rates: uint256[N_COINS], _balances: uint256[N_COINS], _amp: uint256) -> uint256:
+    return self._get_D(self._xp_mem(_rates, _balances), _amp)
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    """
+    @notice The current virtual price of the pool LP token
+    @dev Useful for calculating profits
+    @return LP token virtual price normalized to 1e18
+    """
+    rates: uint256[N_COINS] = self.rate_multipliers
+    D: uint256 = self._get_D(self._xp(rates), self._A())
+    # D is in the units similar to DAI (e.g. converted to precision 1e18)
+    # When balanced, D = n * x_u - total virtual value of the portfolio
+    return D * PRECISION / self.totalSupply
+
+
+@view
+@external
+def calc_token_amount(_amounts: uint256[N_COINS], _is_deposit: bool, _previous: bool = False) -> uint256:
+    """
+    @notice Calculate addition or reduction in token supply from a deposit or withdrawal
+    @dev This calculation accounts for slippage, but not fees.
+         Needed to prevent front-running, not for precise calculations!
+    @param _amounts Amount of each coin being deposited
+    @param _is_deposit set True for deposits, False for withdrawals
+    @param _previous use previous_balances or self.balances
+    @return Expected amount of LP tokens received
+    """
+    amp: uint256 = self._A()
+    balances: uint256[N_COINS] = self.balances
+    rates: uint256[N_COINS] = self.rate_multipliers
+    if _previous:
+        balances = self.previous_balances
+
+    D0: uint256 = self._get_D_mem(rates, balances, amp)
+    for i in range(N_COINS):
+        if _is_deposit:
+            balances[i] += _amounts[i]
+        else:
+            balances[i] -= _amounts[i]
+    D1: uint256 = self._get_D_mem(rates, balances, amp)
+    diff: uint256 = 0
+    if _is_deposit:
+        diff = D1 - D0
+    else:
+        diff = D0 - D1
+    return diff * self.totalSupply / D0
+
+
+@payable
+@external
+@nonreentrant('lock')
+def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256, _receiver: address = msg.sender) -> uint256:
+    """
+    @notice Deposit coins into the pool
+    @param _amounts List of amounts of coins to deposit
+    @param _min_mint_amount Minimum amount of LP tokens to mint from the deposit
+    @param _receiver Address that owns the minted LP tokens
+    @return Amount of LP tokens received by depositing
+    """
+    self._update()
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self.balances
+    rates: uint256[N_COINS] = self.rate_multipliers
+
+    # Initial invariant
+    D0: uint256 = self._get_D_mem(rates, old_balances, amp)
+
+    total_supply: uint256 = self.totalSupply
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        if total_supply == 0:
+            assert _amounts[i] > 0  # dev: initial deposit requires all coins
+        # balances store amounts of c-tokens
+        new_balances[i] += _amounts[i]
+
+    # Invariant after change
+    D1: uint256 = self._get_D_mem(rates, new_balances, amp)
+    assert D1 > D0
+
+    # We need to recalculate the invariant accounting for fees
+    # to calculate fair user's share
+    D2: uint256 = D1
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    mint_amount: uint256 = 0
+    if total_supply > 0:
+        # Only account for fees if we are not the first to deposit
+        fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+        for i in range(N_COINS):
+            ideal_balance: uint256 = D1 * old_balances[i] / D0
+            difference: uint256 = 0
+            new_balance: uint256 = new_balances[i]
+            if ideal_balance > new_balance:
+                difference = ideal_balance - new_balance
+            else:
+                difference = new_balance - ideal_balance
+            fees[i] = fee * difference / FEE_DENOMINATOR
+            self.balances[i] = new_balance - (fees[i] * ADMIN_FEE / FEE_DENOMINATOR)
+            new_balances[i] -= fees[i]
+        D2 = self._get_D_mem(rates, new_balances, amp)
+        mint_amount = total_supply * (D2 - D0) / D0
+    else:
+        self.balances = new_balances
+        mint_amount = D1  # Take the dust if there was any
+    assert mint_amount >= _min_mint_amount, "Slippage screwed you"
+
+    # Take coins from the sender
+    for i in range(N_COINS):
+        if i == 0 and self.coins[0] == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            assert msg.value == _amounts[0]
+        elif _amounts[i] > 0:
+            # "safeTransferFrom" which works for ERC20s which return bool or not
+            _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transferFrom(address,address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(self, bytes32),
+                    convert(_amounts[i], bytes32),
+                ),
+                max_outsize=32,
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)  # dev: failed transfer
+            # end "safeTransferFrom"
+
+    # Mint pool tokens
+    total_supply += mint_amount
+    self.balanceOf[_receiver] += mint_amount
+    self.totalSupply = total_supply
+    log Transfer(ZERO_ADDRESS, _receiver, mint_amount)
+
+    log AddLiquidity(msg.sender, _amounts, fees, D1, total_supply + mint_amount)
+
+    return mint_amount
+
+
+@view
+@internal
+def _get_y(i: int128, j: int128, x: uint256, _xp: uint256[N_COINS]) -> uint256:
+    """
+    Calculate x[j] if one makes x[i] = x
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i != j       # dev: same coin
+    assert j >= 0       # dev: j below zero
+    assert j < N_COINS  # dev: j above N_COINS
+
+    # should be unreachable, but good for safety
+    assert i >= 0
+    assert i < N_COINS
+
+    A: uint256 = self._A()
+    D: uint256 = self._get_D(_xp, A)
+    Ann: uint256 = A * N_COINS
+    c: uint256 = D
+    S: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+
+    for _i in range(N_COINS):
+        if _i == i:
+            _x = x
+        elif _i != j:
+            _x = _xp[_i]
+        else:
+            continue
+        S += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S + D * A_PRECISION / Ann  # - D
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@external
+def get_dy(i: int128, j: int128, _dx: uint256) -> uint256:
+    rates: uint256[N_COINS] = self.rate_multipliers
+    xp: uint256[N_COINS] = self._xp(rates)
+
+    x: uint256 = xp[i] + (_dx * rates[i] / PRECISION)
+    y: uint256 = self._get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y - 1
+    fee: uint256 = self.fee * dy / FEE_DENOMINATOR
+    return (dy - fee) * PRECISION / rates[j]
+
+
+@payable
+@external
+@nonreentrant('lock')
+def exchange(i: int128, j: int128, _dx: uint256, _min_dy: uint256) -> uint256:
+    """
+    @notice Perform an exchange between two coins
+    @dev Index values can be found via the `coins` public getter method
+    @param i Index value for the coin to send
+    @param j Index valie of the coin to recieve
+    @param _dx Amount of `i` being exchanged
+    @param _min_dy Minimum amount of `j` to receive
+    @return Actual amount of `j` received
+    """
+    self._update()
+    rates: uint256[N_COINS] = self.rate_multipliers
+    old_balances: uint256[N_COINS] = self.balances
+    xp: uint256[N_COINS] = self._xp_mem(rates, old_balances)
+
+    x: uint256 = xp[i] + _dx * rates[i] / PRECISION
+    y: uint256 = self._get_y(i, j, x, xp)
+
+    dy: uint256 = xp[j] - y - 1  # -1 just in case there were some rounding errors
+    dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
+
+    # Convert all to real units
+    dy = (dy - dy_fee) * PRECISION / rates[j]
+    assert dy >= _min_dy, "Exchange resulted in fewer coins than expected"
+
+    dy_admin_fee: uint256 = dy_fee * ADMIN_FEE / FEE_DENOMINATOR
+    dy_admin_fee = dy_admin_fee * PRECISION / rates[j]
+
+    # Change balances exactly in same way as we change actual ERC20 coin amounts
+    self.balances[i] = old_balances[i] + _dx
+    # When rounding errors happen, we undercharge admin fee in favor of LP
+    self.balances[j] = old_balances[j] - dy - dy_admin_fee
+
+    coin: address = self.coins[i]
+    if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        assert msg.value == _dx
+    else:
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("transferFrom(address,address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(self, bytes32),
+                convert(_dx, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    coin = self.coins[j]
+    if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        raw_call(msg.sender, b"", value=dy)
+    else:
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("transfer(address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(dy, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    log TokenExchange(msg.sender, i, _dx, j, dy)
+
+    return dy
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(_burn_amount: uint256, _min_amounts: uint256[N_COINS]) -> uint256[N_COINS]:
+    """
+    @notice Withdraw coins from the pool
+    @dev Withdrawal amounts are based on current deposit ratios
+    @param _burn_amount Quantity of LP tokens to burn in the withdrawal
+    @param _min_amounts Minimum amounts of underlying coins to receive
+    @return List of amounts of coins that were withdrawn
+    """
+    self._update()
+    total_supply: uint256 = self.totalSupply
+    amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+
+    for i in range(N_COINS):
+        old_balance: uint256 = self.balances[i]
+        value: uint256 = old_balance * _burn_amount / total_supply
+        assert value >= _min_amounts[i], "Withdrawal resulted in fewer coins than expected"
+        self.balances[i] = old_balance - value
+        amounts[i] = value
+
+        coin: address = self.coins[i]
+        if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            raw_call(msg.sender, b"", value=value)
+        else:
+            _response: Bytes[32] = raw_call(
+                coin,
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(value, bytes32),
+                ),
+                max_outsize=32,
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)
+
+    total_supply -= _burn_amount
+    self.balanceOf[msg.sender] -= _burn_amount
+    self.totalSupply = total_supply
+    log Transfer(msg.sender, ZERO_ADDRESS, _burn_amount)
+
+    log RemoveLiquidity(msg.sender, amounts, empty(uint256[N_COINS]), total_supply - _burn_amount)
+
+    return amounts
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uint256) -> uint256:
+    """
+    @notice Withdraw coins from the pool in an imbalanced amount
+    @param _amounts List of amounts of underlying coins to withdraw
+    @param _max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @return Actual amount of the LP token burned in the withdrawal
+    """
+    self._update()
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self.balances
+    rates: uint256[N_COINS] = self.rate_multipliers
+
+    D0: uint256 = self._get_D_mem(rates, old_balances, amp)
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        new_balances[i] -= _amounts[i]
+    D1: uint256 = self._get_D_mem(rates, new_balances, amp)
+
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        new_balance: uint256 = new_balances[i]
+        ideal_balance: uint256 = D1 * old_balances[i] / D0
+        difference: uint256 = 0
+        if ideal_balance > new_balance:
+            difference = ideal_balance - new_balance
+        else:
+            difference = new_balance - ideal_balance
+        fees[i] = fee * difference / FEE_DENOMINATOR
+        self.balances[i] = new_balance - (fees[i] * ADMIN_FEE / FEE_DENOMINATOR)
+        new_balances[i] = new_balance - fees[i]
+    D2: uint256 = self._get_D_mem(rates, new_balances, amp)
+
+    total_supply: uint256 = self.totalSupply
+    burn_amount: uint256 = (D0 - D2) * total_supply / D0
+    assert burn_amount != 0  # dev: zero tokens burned
+    burn_amount += 1  # In case of rounding errors - make it unfavorable for the "attacker"
+    assert burn_amount <= _max_burn_amount, "Slippage screwed you"
+
+    total_supply -= burn_amount
+    self.totalSupply = total_supply
+    self.balanceOf[msg.sender] -= burn_amount
+    log Transfer(msg.sender, ZERO_ADDRESS, burn_amount)
+
+    for i in range(N_COINS):
+        if _amounts[i] != 0:
+            coin: address = self.coins[i]
+            if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+                raw_call(msg.sender, b"", value=_amounts[i])
+            else:
+                _response: Bytes[32] = raw_call(
+                    coin,
+                    concat(
+                        method_id("transfer(address,uint256)"),
+                        convert(msg.sender, bytes32),
+                        convert(_amounts[i], bytes32),
+                    ),
+                    max_outsize=32,
+                )
+                if len(_response) > 0:
+                    assert convert(_response, bool)
+
+    log RemoveLiquidityImbalance(msg.sender, _amounts, fees, D1, total_supply - burn_amount)
+
+    return burn_amount
+
+
+@pure
+@internal
+def _get_y_D(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
+    """
+    Calculate x[i] if one reduces D from being calculated for xp to D
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i >= 0  # dev: i below zero
+    assert i < N_COINS  # dev: i above N_COINS
+
+    Ann: uint256 = A * N_COINS
+    c: uint256 = D
+    S: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+
+    for _i in range(N_COINS):
+        if _i != i:
+            _x = _xp[_i]
+        else:
+            continue
+        S += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S + D * A_PRECISION / Ann
+    y: uint256 = D
+
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@internal
+def _calc_withdraw_one_coin(_token_amount: uint256, i: int128, _balances: uint256[N_COINS]) -> (uint256, uint256, uint256):
+    # First, need to calculate
+    # * Get current D
+    # * Solve Eqn against y_i for D - _token_amount
+    amp: uint256 = self._A()
+    rates: uint256[N_COINS] = self.rate_multipliers
+    xp: uint256[N_COINS] = self._xp_mem(rates, _balances)
+    D0: uint256 = self._get_D(xp, amp)
+    total_supply: uint256 = self.totalSupply
+    D1: uint256 = D0 - _token_amount * D0 / total_supply
+    new_y: uint256 = self._get_y_D(amp, i, xp, D1)
+    xp_reduced: uint256[N_COINS] = xp
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    for j in range(N_COINS):
+        dx_expected: uint256 = 0
+        if j == i:
+            dx_expected = xp[j] * D1 / D0 - new_y
+        else:
+            dx_expected = xp[j] - xp[j] * D1 / D0
+        xp_reduced[j] -= fee * dx_expected / FEE_DENOMINATOR
+
+    dy: uint256 = xp_reduced[i] - self._get_y_D(amp, i, xp_reduced, D1)
+    rate: uint256 = rates[i]
+    dy = (dy - 1) * PRECISION / rate  # Withdraw less to account for rounding errors
+    dy_0: uint256 = (xp[i] - new_y) * PRECISION / rate  # w/o fees
+
+    return dy, dy_0 - dy, total_supply
+
+
+@view
+@external
+def calc_withdraw_one_coin(_burn_amount: uint256, i: int128, _previous: bool = False) -> uint256:
+    """
+    @notice Calculate the amount received when withdrawing a single coin
+    @param _burn_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @param _previous indicate to use previous_balances or current balances
+    @return Amount of coin received
+    """
+    balances: uint256[N_COINS] = self.balances
+    if _previous:
+        balances = self.previous_balances
+    return self._calc_withdraw_one_coin(_burn_amount, i, balances)[0]
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(_burn_amount: uint256, i: int128, _min_amount: uint256) -> uint256:
+    """
+    @notice Withdraw a single coin from the pool
+    @param _burn_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @param _min_amount Minimum amount of coin to receive
+    @return Amount of coin received
+    """
+    self._update()
+
+    dy: uint256 = 0
+    dy_fee: uint256 = 0
+    total_supply: uint256 = 0
+    dy, dy_fee, total_supply = self._calc_withdraw_one_coin(_burn_amount, i, self.balances)
+    assert dy >= _min_amount, "Not enough coins removed"
+
+    self.balances[i] -= (dy + dy_fee * ADMIN_FEE / FEE_DENOMINATOR)
+    total_supply = self.totalSupply - _burn_amount
+    self.totalSupply = total_supply
+    self.balanceOf[msg.sender] -= _burn_amount
+    log Transfer(msg.sender, ZERO_ADDRESS, _burn_amount)
+
+    _coin: address = self.coins[i]
+    if _coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        raw_call(msg.sender, b"", value=dy)
+    else:
+        _response: Bytes[32] = raw_call(
+            self.coins[i],
+            concat(
+                method_id("transfer(address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(dy, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    log RemoveLiquidityOne(msg.sender, _burn_amount, dy, total_supply - _burn_amount)
+
+    return dy
+
+
+### Admin functions ###
+@external
+def ramp_A(_future_A: uint256, _future_time: uint256):
+    assert msg.sender == self.admin  # dev: only admin
+    assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
+    assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
+
+    initial_A: uint256 = self._A()
+    future_A_p: uint256 = _future_A * A_PRECISION
+
+    assert _future_A > 0 and _future_A < MAX_A
+    if future_A_p < initial_A:
+        assert future_A_p * MAX_A_CHANGE >= initial_A
+    else:
+        assert future_A_p <= initial_A * MAX_A_CHANGE
+
+    self.initial_A = initial_A
+    self.future_A = future_A_p
+    self.initial_A_time = block.timestamp
+    self.future_A_time = _future_time
+
+    log RampA(initial_A, future_A_p, block.timestamp, _future_time)
+
+
+@external
+def stop_ramp_A():
+    assert msg.sender == self.admin  # dev: only admin
+
+    current_A: uint256 = self._A()
+    self.initial_A = current_A
+    self.future_A = current_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = block.timestamp
+    # now (block.timestamp < t1) is always False, so we return saved A
+
+    log StopRampA(current_A, block.timestamp)
+
+
+@view
+@external
+def admin_balances(i: uint256) -> uint256:
+    coin: address = self.coins[i]
+    if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        return self.balance - self.balances[i]
+    else:
+        return ERC20(coin).balanceOf(self) - self.balances[i]
+
+
+@external
+def withdraw_admin_fees():
+    # Do some fee burning magic through factory
+    factory: address = self.factory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-brownie-token-tester==0.0.3
-eth-brownie>=1.13.0,<2.0.0
+brownie-token-tester==0.3.2
+eth-brownie>=1.14.6,<2.0.0

--- a/tests/plain_pools/test_withdraw_admin_fees.py
+++ b/tests/plain_pools/test_withdraw_admin_fees.py
@@ -1,0 +1,32 @@
+import pytest
+
+SWAP_AMOUNT = 1e6
+
+@pytest.fixture()
+def setUp(alice, factory, bob, swap_plain, plain_coins, charlie):
+    amounts = []
+    for coin in plain_coins[:2]:
+        amount = 1e6 * 10 ** coin.decimals()
+        amounts.append(amount)
+        coin._mint_for_testing(alice, amount, {'from': alice})
+        coin.approve(swap_plain, 2**256-1, {'from': alice})
+
+    swap_plain.add_liquidity(amounts, 0, {'from': alice})
+
+    factory.set_fee_receiver(swap_plain, charlie)
+
+    amount = SWAP_AMOUNT * 10**coin.decimals()
+    plain_coins[0]._mint_for_testing(bob, amount, {'from': bob})
+    plain_coins[0].approve(swap_plain, amount, {'from': bob})
+    swap_plain.exchange(0, 1, amount, 0, {'from': bob})
+
+
+def test_withdraw_admin_fees(bob, setUp, plain_coins, swap_plain, charlie, alice):
+    fees = []
+    for i, coin in enumerate(plain_coins[:2]):
+        assert coin.balanceOf(charlie) == 0
+        fees.append(swap_plain.admin_balances(i))
+    swap_plain.withdraw_admin_fees({'from': bob})
+    for i, coin in enumerate(plain_coins[:2]):
+        assert coin.balanceOf(charlie) == fees[i]
+

--- a/tests/pools/test_twap_remove_liquidity.py
+++ b/tests/pools/test_twap_remove_liquidity.py
@@ -21,6 +21,8 @@ def test_remove_liquidity(alice, swap, wrapped_coins, min_amount, initial_amount
     elapsed = after - start
 
     for i, balance in enumerate(balances_before):
+        if i == len(twap):
+            break
         assert twap[i] == twap_control[i] + (balance * elapsed)
 
 
@@ -38,4 +40,6 @@ def test_remove_partial(alice, swap, wrapped_coins, initial_amounts):
     elapsed = after - start
 
     for i, balance in enumerate(balances_before):
+        if i == len(twap):
+            break
         assert twap[i] == twap_control[i] + (balance * elapsed)

--- a/tests/pools/test_twap_remove_liquidity_imbalance.py
+++ b/tests/pools/test_twap_remove_liquidity_imbalance.py
@@ -19,6 +19,8 @@ def test_remove_balanced(alice, swap, wrapped_coins, divisor, initial_amounts):
     elapsed = after - start
 
     for i, balance in enumerate(balances_before):
+        if i == len(twap):
+            break
         assert twap[i] == twap_control[i] + (balance * elapsed)
 
 
@@ -38,4 +40,6 @@ def test_remove_one(alice, swap, wrapped_coins, idx, initial_amounts):
     elapsed = after - start
 
     for i, balance in enumerate(balances_before):
+        if i == len(twap):
+            break
         assert twap[i] == twap_control[i] + (balance * elapsed)

--- a/tests/pools/test_twap_remove_liquidity_one_coin.py
+++ b/tests/pools/test_twap_remove_liquidity_one_coin.py
@@ -20,6 +20,8 @@ def test_amount_received(chain, alice, swap, wrapped_coins, wrapped_decimals, ba
     elapsed = after - start
 
     for i, balance in enumerate(balances_before):
+        if i == len(twap):
+            break
         assert twap[i] == twap_control[i] + (balance * elapsed)
 
 
@@ -40,4 +42,6 @@ def test_lp_token_balance(alice, swap, idx, divisor):
     elapsed = after - start
 
     for i, balance in enumerate(balances_before):
+        if i == len(twap):
+            break
         assert twap[i] == twap_control[i] + (balance * elapsed)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -32,7 +32,7 @@ def test_find_pool_underlying_base_pool_only(factory, underlying_coins, sending,
 
 
 def test_factory(factory, swap):
-    assert factory.get_n_coins(swap) == [2, 4]
+    assert factory.get_meta_n_coins(swap) == [2, 4]
 
 
 def test_get_coins(factory, swap, wrapped_coins):
@@ -53,12 +53,12 @@ def test_get_underlying_decimals(factory, swap, underlying_decimals):
     assert factory.get_underlying_decimals(swap) == underlying_decimals + [0] * 4
 
 
-def test_get_rates(factory, swap, base_pool):
-    assert factory.get_rates(swap) == [10**18, base_pool.get_virtual_price()]
+def test_get_metapool_rates(factory, swap, base_pool):
+    assert factory.get_metapool_rates(swap) == [10**18, base_pool.get_virtual_price()]
 
 
 def test_get_balances(factory, swap):
-    assert factory.get_balances(swap) == [swap.balances(0), swap.balances(1)]
+    assert factory.get_balances(swap) == [swap.balances(0), swap.balances(1), 0, 0]
 
 
 def get_underlying_balances(factory, swap, base_pool):


### PR DESCRIPTION
## What I did

This PR updates the factory in several ways:
* Existing (factory deployed) metapools can be added to the list of pools
* Plain pools can be deployed (up to 4 coins per pool)
* Plain and metapools can have multiple implementations. This allows for deploying metapool implementations supporting rebase (e.g. aTokens) tokens. 

*Note*: The `PlainPoolImplementation` still needs to be fully tested (a separate PR will be created for the the updated test suite).