### PR TITLE
Refactor/deploy checks

### DIFF
--- a/contracts/implementations/meta/MetaBTC.vy
+++ b/contracts/implementations/meta/MetaBTC.vy
@@ -26,6 +26,7 @@ interface Curve:
 interface Factory:
     def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
+    def admin() -> address: view
 
 
 event Transfer:
@@ -109,7 +110,6 @@ MAX_A: constant(uint256) = 10 ** 6
 MAX_A_CHANGE: constant(uint256) = 10
 MIN_RAMP_TIME: constant(uint256) = 86400
 
-admin: public(address)
 factory: address
 
 coins: public(address[N_COINS])
@@ -1033,7 +1033,7 @@ def remove_liquidity_one_coin(
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1056,7 +1056,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A

--- a/contracts/implementations/meta/MetaBTC.vy
+++ b/contracts/implementations/meta/MetaBTC.vy
@@ -146,36 +146,28 @@ def initialize(
     _name: String[32],
     _symbol: String[10],
     _coin: address,
-    _decimals: uint256,
+    _rate_multiplier: uint256,
     _A: uint256,
-    _fee: uint256,
-    _admin: address,
+    _fee: uint256
 ):
     """
     @notice Contract initializer
     @param _name Name of the new pool
     @param _symbol Token symbol
     @param _coin Addresses of ERC20 conracts of coins
-    @param _decimals Number of decimals in `_coin`
-    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _rate_multiplier Rate multiplier for `_coin` (10 ** (36 - decimals))
+    @param _A Amplification coefficient multiplied by n ** (n - 1)
     @param _fee Fee to charge for exchanges
-    @param _admin Admin address
     """
-    # things break if a token has >18 decimals
-    assert _decimals < 19
-    # fee must be between 0.04% and 1%
-    assert _fee >= 4000000
-    assert _fee <= 100000000
     # check if fee was already set to prevent initializing contract twice
     assert self.fee == 0
 
     A: uint256 = _A * A_PRECISION
     self.coins = [_coin, 0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3]
-    self.rate_multiplier = 10 ** (36 - _decimals)
+    self.rate_multiplier = _rate_multiplier
     self.initial_A = A
     self.future_A = A
     self.fee = _fee
-    self.admin = _admin
     self.factory = msg.sender
 
     self.name = concat("Curve.fi Factory BTC Metapool: ", _name)

--- a/contracts/implementations/meta/MetaBTCRebase.vy
+++ b/contracts/implementations/meta/MetaBTCRebase.vy
@@ -26,6 +26,7 @@ interface Curve:
 interface Factory:
     def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
+    def admin() -> address: view
 
 
 event Transfer:
@@ -109,7 +110,6 @@ MAX_A: constant(uint256) = 10 ** 6
 MAX_A_CHANGE: constant(uint256) = 10
 MIN_RAMP_TIME: constant(uint256) = 86400
 
-admin: public(address)
 factory: address
 
 coins: public(address[N_COINS])
@@ -1041,7 +1041,7 @@ def remove_liquidity_one_coin(
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1064,7 +1064,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A

--- a/contracts/implementations/meta/MetaBTCRebase.vy
+++ b/contracts/implementations/meta/MetaBTCRebase.vy
@@ -146,36 +146,28 @@ def initialize(
     _name: String[32],
     _symbol: String[10],
     _coin: address,
-    _decimals: uint256,
+    _rate_multiplier: uint256,
     _A: uint256,
-    _fee: uint256,
-    _admin: address,
+    _fee: uint256
 ):
     """
     @notice Contract initializer
     @param _name Name of the new pool
     @param _symbol Token symbol
     @param _coin Addresses of ERC20 conracts of coins
-    @param _decimals Number of decimals in `_coin`
-    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _rate_multiplier Rate multiplier for `_coin` (10 ** (36 - decimals))
+    @param _A Amplification coefficient multiplied by n ** (n - 1)
     @param _fee Fee to charge for exchanges
-    @param _admin Admin address
     """
-    # things break if a token has >18 decimals
-    assert _decimals < 19
-    # fee must be between 0.04% and 1%
-    assert _fee >= 4000000
-    assert _fee <= 100000000
     # check if fee was already set to prevent initializing contract twice
     assert self.fee == 0
 
     A: uint256 = _A * A_PRECISION
     self.coins = [_coin, 0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3]
-    self.rate_multiplier = 10 ** (36 - _decimals)
+    self.rate_multiplier = _rate_multiplier
     self.initial_A = A
     self.future_A = A
     self.fee = _fee
-    self.admin = _admin
     self.factory = msg.sender
 
     self.name = concat("Curve.fi Factory BTC Metapool: ", _name)

--- a/contracts/implementations/meta/MetaUSD.vy
+++ b/contracts/implementations/meta/MetaUSD.vy
@@ -26,6 +26,7 @@ interface Curve:
 interface Factory:
     def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
+    def admin() -> address: view
 
 
 event Transfer:
@@ -109,7 +110,6 @@ MAX_A: constant(uint256) = 10 ** 6
 MAX_A_CHANGE: constant(uint256) = 10
 MIN_RAMP_TIME: constant(uint256) = 86400
 
-admin: public(address)
 factory: address
 
 coins: public(address[N_COINS])
@@ -1039,7 +1039,7 @@ def remove_liquidity_one_coin(
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1062,7 +1062,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A

--- a/contracts/implementations/meta/MetaUSD.vy
+++ b/contracts/implementations/meta/MetaUSD.vy
@@ -146,36 +146,28 @@ def initialize(
     _name: String[32],
     _symbol: String[10],
     _coin: address,
-    _decimals: uint256,
+    _rate_multiplier: uint256,
     _A: uint256,
-    _fee: uint256,
-    _admin: address,
+    _fee: uint256
 ):
     """
     @notice Contract initializer
     @param _name Name of the new pool
     @param _symbol Token symbol
     @param _coin Addresses of ERC20 conracts of coins
-    @param _decimals Number of decimals in `_coin`
-    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _rate_multiplier Rate multiplier for `_coin` (10 ** (36 - decimals))
+    @param _A Amplification coefficient multiplied by n ** (n - 1)
     @param _fee Fee to charge for exchanges
-    @param _admin Admin address
     """
-    # things break if a token has >18 decimals
-    assert _decimals < 19
-    # fee must be between 0.04% and 1%
-    assert _fee >= 4000000
-    assert _fee <= 100000000
     # check if fee was already set to prevent initializing contract twice
     assert self.fee == 0
 
     A: uint256 = _A * A_PRECISION
     self.coins = [_coin, 0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490]
-    self.rate_multiplier = 10 ** (36 - _decimals)
+    self.rate_multiplier = _rate_multiplier
     self.initial_A = A
     self.future_A = A
     self.fee = _fee
-    self.admin = _admin
     self.factory = msg.sender
 
     self.name = concat("Curve.fi Factory USD Metapool: ", _name)

--- a/contracts/implementations/meta/MetaUSDRebase.vy
+++ b/contracts/implementations/meta/MetaUSDRebase.vy
@@ -26,6 +26,7 @@ interface Curve:
 interface Factory:
     def convert_metapool_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
+    def admin() -> address: view
 
 
 event Transfer:
@@ -109,7 +110,6 @@ MAX_A: constant(uint256) = 10 ** 6
 MAX_A_CHANGE: constant(uint256) = 10
 MIN_RAMP_TIME: constant(uint256) = 86400
 
-admin: public(address)
 factory: address
 
 coins: public(address[N_COINS])
@@ -1046,7 +1046,7 @@ def remove_liquidity_one_coin(
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1069,7 +1069,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == self.admin  # dev: only owner
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A

--- a/contracts/implementations/meta/MetaUSDRebase.vy
+++ b/contracts/implementations/meta/MetaUSDRebase.vy
@@ -146,36 +146,28 @@ def initialize(
     _name: String[32],
     _symbol: String[10],
     _coin: address,
-    _decimals: uint256,
+    _rate_multiplier: uint256,
     _A: uint256,
-    _fee: uint256,
-    _admin: address,
+    _fee: uint256
 ):
     """
     @notice Contract initializer
     @param _name Name of the new pool
     @param _symbol Token symbol
     @param _coin Addresses of ERC20 conracts of coins
-    @param _decimals Number of decimals in `_coin`
-    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _rate_multiplier Rate multiplier for `_coin` (10 ** (36 - decimals))
+    @param _A Amplification coefficient multiplied by n ** (n - 1)
     @param _fee Fee to charge for exchanges
-    @param _admin Admin address
     """
-    # things break if a token has >18 decimals
-    assert _decimals < 19
-    # fee must be between 0.04% and 1%
-    assert _fee >= 4000000
-    assert _fee <= 100000000
     # check if fee was already set to prevent initializing contract twice
     assert self.fee == 0
 
     A: uint256 = _A * A_PRECISION
     self.coins = [_coin, 0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490]
-    self.rate_multiplier = 10 ** (36 - _decimals)
+    self.rate_multiplier = _rate_multiplier
     self.initial_A = A
     self.future_A = A
     self.fee = _fee
-    self.admin = _admin
     self.factory = msg.sender
 
     self.name = concat("Curve.fi Factory USD Metapool: ", _name)

--- a/contracts/implementations/plain-2/Plain2Basic.vy
+++ b/contracts/implementations/plain-2/Plain2Basic.vy
@@ -13,6 +13,7 @@ from vyper.interfaces import ERC20
 interface Factory:
     def convert_fees() -> bool: nonpayable
     def fee_receiver(_base_pool: address) -> address: view
+    def admin() -> address: view
 
 
 event Transfer:
@@ -80,7 +81,6 @@ MAX_A: constant(uint256) = 10 ** 6
 MAX_A_CHANGE: constant(uint256) = 10
 MIN_RAMP_TIME: constant(uint256) = 86400
 
-admin: public(address)
 factory: address
 
 coins: public(address[N_COINS])
@@ -897,7 +897,7 @@ def remove_liquidity_one_coin(_burn_amount: uint256, i: int128, _min_amount: uin
 ### Admin functions ###
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == self.admin  # dev: only admin
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -920,7 +920,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == self.admin  # dev: only admin
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A

--- a/contracts/implementations/plain-2/Plain2Basic.vy
+++ b/contracts/implementations/plain-2/Plain2Basic.vy
@@ -117,46 +117,41 @@ def initialize(
     _name: String[32],
     _symbol: String[10],
     _coins: address[4],
-    _decimals: uint256[4],
+    _rate_multipliers: uint256[4],
     _A: uint256,
     _fee: uint256,
-    _admin: address
 ):
     """
     @notice Contract constructor
     @param _name Name of the new pool
     @param _symbol Token symbol
     @param _coins List of all ERC20 conract addresses of coins
-    @param _decimals List of number of decimals in coins
+    @param _rate_multipliers List of number of decimals in coins
     @param _A Amplification coefficient multiplied by n * (n - 1)
     @param _fee Fee to charge for exchanges
-    @param _admin Admin address
     """
-
-    # fee must be between 0.04% and 1%
-    assert _fee >= 4000000
-    assert _fee <= 100000000
     # check if fee was already set to prevent initializing contract twice
     assert self.fee == 0
 
     for i in range(N_COINS):
-        if _coins[i] == ZERO_ADDRESS:
+        coin: address = _coins[i]
+        if coin == ZERO_ADDRESS:
             break
-        if _coins[i] == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
-            assert i == 0  # dev: ETH must be at index 0
-        # things break if a token has >18 decimals
-        assert _decimals[i] < 19
-        self.rate_multipliers[i] = 10 ** (36 - _decimals[i])
-        self.coins[i] = _coins[i]
+        self.coins[i] = coin
+        self.rate_multipliers[i] = _rate_multipliers[i]
 
-    self.initial_A = _A * A_PRECISION
-    self.future_A = _A * A_PRECISION
+    A: uint256 = _A * A_PRECISION
+    self.initial_A = A
+    self.future_A = A
     self.fee = _fee
-    self.admin = _admin
     self.factory = msg.sender
 
     self.name = concat("Curve.fi Factory Plain Pool: ", _name)
     self.symbol = concat(_symbol, "-f")
+
+    # fire a transfer event so block explorers identify the contract as an ERC20
+    log Transfer(ZERO_ADDRESS, self, 0)
+
 
 ### ERC20 Functionality ###
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -219,7 +219,7 @@ def test_add_base_pool_only_admin(factory, base_pool, bob, fee_receiver, impleme
         )
 
 
-def test_deploy_metapool(MetaUSD, new_factory, new_factory_setup, base_pool, alice, bob):
+def test_deploy_metapool(MetaUSD, new_factory, new_factory_setup, base_pool, bob):
     coin = ERC20(decimals=7)
 
     tx = new_factory.deploy_metapool(
@@ -231,7 +231,6 @@ def test_deploy_metapool(MetaUSD, new_factory, new_factory_setup, base_pool, ali
     assert swap.coins(0) == coin
     assert swap.A() == 12345
     assert swap.fee() == 50000000
-    assert swap.admin() == alice
 
     assert new_factory.pool_count() == 1
     assert new_factory.pool_list(0) == swap
@@ -279,7 +278,7 @@ def test_add_existing_metapools_duplicate_pool(
         )
 
 
-def test_deploy_plain_pool(Plain2Basic, is_rebase, new_factory_setup, new_factory, alice, bob):
+def test_deploy_plain_pool(Plain2Basic, is_rebase, new_factory_setup, new_factory, bob):
     if is_rebase:
         pytest.skip()
 
@@ -296,7 +295,6 @@ def test_deploy_plain_pool(Plain2Basic, is_rebase, new_factory_setup, new_factor
 
     assert swap.A() == 12345
     assert swap.fee() == 50000000
-    assert swap.admin() == alice
 
     assert new_factory.pool_count() == 1
     assert new_factory.pool_list(0) == swap


### PR DESCRIPTION
### What I did
* Where possible, move assertions out of the implementation `initialize` function and into the factory `deploy_` functions. This saves us some bytecode space that will be useful later.
* Stop storing the `admin` locally in contracts and instead call to get the address from the factory.  Makes it easier to change ownership.