### PR TITLE
test: Owner Proxy

### DIFF
--- a/contracts/OwnerProxy.vy
+++ b/contracts/OwnerProxy.vy
@@ -13,12 +13,12 @@ interface Curve:
 interface Factory:
     def add_base_pool(
         _base_pool: address,
-        _metapool_implementation: address,
         _fee_receiver: address,
+        _implementations: address[10],
     ): nonpayable
     def set_metapool_implementations(
         _base_pool: address,
-    _implementations: address[10],
+        _implementations: address[10],
     ): nonpayable
     def set_plain_implementations(
         _n_coins: uint256,
@@ -121,12 +121,13 @@ def stop_ramp_A(_pool: address):
 def add_base_pool(
     _target: address,
     _base_pool: address,
-    _metapool_implementation: address,
-    _fee_receiver: address
+    _fee_receiver: address,
+    _implementations: address[10],
 ):
-    assert msg.sender == self.ownership_admin
 
-    Factory(_target).add_base_pool(_base_pool, _metapool_implementation, _fee_receiver)
+    assert msg.sender == self.ownership_admin, "Access denied"
+
+    Factory(_target).add_base_pool(_base_pool, _fee_receiver, _implementations)
 
 
 @external

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 pytest_plugins = [
     "fixtures.accounts",
+    "fixtures.actions",
     "fixtures.coins",
     "fixtures.constants",
     "fixtures.deployments",
@@ -27,77 +28,3 @@ def pytest_addoption(parser):
 @pytest.fixture(autouse=True)
 def isolation_setup(fn_isolation):
     pass
-
-
-# shared logic for pool and base_pool setup fixtures
-
-
-def _add_liquidity(acct, swap, coins, amounts):
-    swap.add_liquidity(amounts, 0, {"from": acct})
-
-
-def _mint(acct, wrapped_coins, wrapped_amounts, underlying_coins, underlying_amounts):
-    for coin, amount in zip(wrapped_coins, wrapped_amounts):
-        coin._mint_for_testing(acct, amount, {"from": acct})
-
-    for coin, amount in zip(underlying_coins[1:], underlying_amounts[1:]):
-        coin._mint_for_testing(acct, amount, {"from": acct})
-
-
-def _approve(owner, spender, *coins):
-    for coin in set(x for i in coins for x in i):
-        coin.approve(spender, 2 ** 256 - 1, {"from": owner})
-
-
-# pool setup fixtures
-
-
-@pytest.fixture()
-def add_initial_liquidity(
-    alice, mint_alice, approve_alice, underlying_coins, swap, initial_amounts
-):
-    # mint (10**7 * precision) of each coin in the pool
-    _add_liquidity(alice, swap, underlying_coins, initial_amounts)
-
-
-@pytest.fixture()
-def mint_bob(bob, underlying_coins, wrapped_coins, initial_amounts, initial_amounts_underlying):
-    _mint(bob, wrapped_coins, initial_amounts, underlying_coins, initial_amounts_underlying)
-
-
-@pytest.fixture(scope="module")
-def approve_bob(bob, swap, underlying_coins, wrapped_coins):
-    _approve(bob, swap, underlying_coins, wrapped_coins)
-
-
-@pytest.fixture()
-def mint_alice(alice, underlying_coins, wrapped_coins, initial_amounts, initial_amounts_underlying):
-    _mint(alice, wrapped_coins, initial_amounts, underlying_coins, initial_amounts_underlying)
-
-
-@pytest.fixture(scope="module")
-def approve_alice(alice, swap, underlying_coins, wrapped_coins):
-    _approve(alice, swap, underlying_coins, wrapped_coins)
-
-
-@pytest.fixture()
-def approve_zap(alice, bob, zap, swap, underlying_coins, initial_amounts_underlying):
-    for underlying, amount in zip(underlying_coins, initial_amounts_underlying):
-        if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
-            continue
-        underlying.approve(zap, 2 ** 256 - 1, {"from": alice})
-        underlying.approve(zap, 2 ** 256 - 1, {"from": bob})
-
-    swap.approve(zap, 2 ** 256 - 1, {"from": alice})
-    swap.approve(zap, 2 ** 256 - 1, {"from": bob})
-
-
-# Added for rebase tokens
-
-
-@pytest.fixture()
-def mint_and_deposit(wrapped_rebase_coins, wrapped_rebase_amounts, alice, swap_rebase):
-    for coin, amount in zip(wrapped_rebase_coins, wrapped_rebase_amounts):
-        coin._mint_for_testing(alice, amount, {"from": alice})
-        coin.approve(swap_rebase, amount, {"from": alice})
-    swap_rebase.add_liquidity(wrapped_rebase_amounts, 0, {"from": alice})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 from brownie import ZERO_ADDRESS, Contract
 from brownie_tokens import ERC20, MintableForkToken
 
+pytest_plugins = ["fixtures.accounts"]
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -22,31 +24,6 @@ def pytest_addoption(parser):
 @pytest.fixture(autouse=True)
 def isolation_setup(fn_isolation):
     pass
-
-
-@pytest.fixture(scope="session")
-def alice(accounts):
-    yield accounts[0]
-
-
-@pytest.fixture(scope="session")
-def bob(accounts):
-    yield accounts[1]
-
-
-@pytest.fixture(scope="session")
-def charlie(accounts):
-    yield accounts[2]
-
-
-@pytest.fixture(scope="session")
-def dave(accounts):
-    yield accounts[3]
-
-
-@pytest.fixture(scope="session")
-def fee_receiver(accounts):
-    yield accounts[4]
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 import pytest
-from brownie import ZERO_ADDRESS
 
-pytest_plugins = ["fixtures.accounts", "fixtures.coins", "fixtures.deployments"]
+pytest_plugins = [
+    "fixtures.accounts",
+    "fixtures.coins",
+    "fixtures.constants",
+    "fixtures.deployments",
+]
 
 
 def pytest_addoption(parser):
@@ -23,42 +27,6 @@ def pytest_addoption(parser):
 @pytest.fixture(autouse=True)
 def isolation_setup(fn_isolation):
     pass
-
-
-@pytest.fixture(scope="module", params=[0, 1])
-def is_rebase(request):
-    yield request.param
-
-
-@pytest.fixture(scope="module")
-def wrapped_decimals(wrapped_coins):
-    yield [i.decimals() if i != ZERO_ADDRESS else 0 for i in wrapped_coins]
-
-
-@pytest.fixture(scope="module")
-def plain_decimals(plain_coins):
-    yield [i.decimals() if i != ZERO_ADDRESS else 0 for i in plain_coins]
-
-
-@pytest.fixture(scope="module")
-def underlying_decimals(underlying_coins):
-    yield [i.decimals() for i in underlying_coins]
-
-
-@pytest.fixture(scope="module")
-def initial_amounts(wrapped_decimals, base_pool):
-    # 1e6 of each coin - used to make an even initial deposit in many test setups
-    amounts = [10 ** i * 1000000 for i in wrapped_decimals]
-    amounts[1] = amounts[1] * 10 ** 18 // base_pool.get_virtual_price()
-    yield amounts
-
-
-@pytest.fixture(scope="module")
-def initial_amounts_underlying(underlying_decimals):
-    # 1e6 of each coin - used to make an even initial deposit in many test setups
-    amounts = [10 ** i * 1000000 for i in underlying_decimals]
-    amounts[1:] = [i // 3 for i in amounts[1:]]
-    yield amounts
 
 
 # shared logic for pool and base_pool setup fixtures
@@ -125,13 +93,6 @@ def approve_zap(alice, bob, zap, swap, underlying_coins, initial_amounts_underly
 
 
 # Added for rebase tokens
-
-
-@pytest.fixture(scope="module")
-def wrapped_rebase_amounts(base_pool, wrapped_coins, wrapped_decimals):
-    wrapped_amounts = [10 ** i * 1000000 for i in wrapped_decimals]
-    wrapped_amounts[1] = wrapped_amounts[1] * 10 ** 18 // base_pool.get_virtual_price()
-    yield wrapped_amounts
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 import pytest
-from brownie import ZERO_ADDRESS, Contract
-from brownie_tokens import ERC20, MintableForkToken
+from brownie import ZERO_ADDRESS
 
-pytest_plugins = ["fixtures.accounts", "fixtures.deployments"]
+pytest_plugins = ["fixtures.accounts", "fixtures.coins", "fixtures.deployments"]
 
 
 def pytest_addoption(parser):
@@ -26,91 +25,9 @@ def isolation_setup(fn_isolation):
     pass
 
 
-@pytest.fixture(scope="module")
-def rebase_coin(alice, ATokenMock, AaveLendingPoolMock, ERC20Mock):
-    aave_lending_pool_mock = AaveLendingPoolMock.deploy({"from": alice})
-    erc20_mock = ERC20Mock.deploy("ERC20MOCK", "ERC", 18, {"from": alice})
-    yield ATokenMock.deploy(
-        "Rebase Mock", "MOK", 18, erc20_mock, aave_lending_pool_mock, {"from": alice}
-    )
-
-
-@pytest.fixture(scope="module")
-def zap(DepositZapUSD, alice):
-    yield DepositZapUSD.deploy({"from": alice})
-
-
-@pytest.fixture(scope="module")
-def base_pool():
-    pool = Contract("0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7")
-
-    # ensure the base pool is balanced so our tests are deterministic
-    max_balance = max([pool.balances(0), pool.balances(1) * 10 ** 12, pool.balances(2) * 10 ** 12])
-    ideal_balances = [max_balance, max_balance // 10 ** 12, max_balance // 10 ** 12]
-    for i, amount in enumerate(ideal_balances):
-        balance = pool.balances(i)
-        if balance < amount:
-            MintableForkToken(pool.coins(i))._mint_for_testing(pool, amount - balance)
-    pool.donate_admin_fees({"from": pool.owner()})
-
-    yield pool
-
-
-@pytest.fixture(scope="module")
-def base_pool_btc(alice, fee_receiver, implementation_btc, factory, implementation_rebase_btc):
-    pool = Contract("0x7fC77b5c7614E1533320Ea6DDc2Eb61fa00A9714")
-    factory.add_base_pool(
-        pool,
-        fee_receiver,
-        [implementation_btc, implementation_rebase_btc] + [ZERO_ADDRESS] * 8,
-        {"from": alice},
-    )
-
-    yield pool
-
-
 @pytest.fixture(scope="module", params=[0, 1])
 def is_rebase(request):
     yield request.param
-
-
-@pytest.fixture(scope="module")
-def wrapped_coins(is_rebase, coin, rebase_coin, base_lp_token):
-    if is_rebase:
-        yield [rebase_coin, base_lp_token]
-    else:
-        yield [coin, base_lp_token]
-
-
-@pytest.fixture(scope="module")
-def underlying_coins(coin, is_rebase, rebase_coin):
-    BASE_COINS = [
-        "0x6B175474E89094C44Da98b954EedeAC495271d0F",  # DAI
-        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # USDC
-        "0xdAC17F958D2ee523a2206206994597C13D831ec7",  # USDT
-    ]
-    if is_rebase:
-        yield [rebase_coin] + [MintableForkToken(i) for i in BASE_COINS]
-    else:
-        yield [coin] + [MintableForkToken(i) for i in BASE_COINS]
-
-
-@pytest.fixture(scope="module")
-def plain_coins():
-    yield [ERC20(decimals=7), ERC20(decimals=9), ZERO_ADDRESS, ZERO_ADDRESS]
-
-
-@pytest.fixture(scope="module")
-def base_lp_token():
-    yield MintableForkToken("0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490")
-
-
-@pytest.fixture(scope="module")
-def coin(pytestconfig):
-    yield ERC20(
-        decimals=pytestconfig.getoption("decimals"),
-        success=eval(pytestconfig.getoption("return_value")),
-    )
 
 
 @pytest.fixture(scope="module")
@@ -208,16 +125,6 @@ def approve_zap(alice, bob, zap, swap, underlying_coins, initial_amounts_underly
 
 
 # Added for rebase tokens
-
-
-@pytest.fixture(scope="module")
-def wrapped_rebase_coins(rebase_coin, base_lp_token):
-    yield [rebase_coin, base_lp_token]
-
-
-@pytest.fixture(scope="module")
-def wrapped_rebase_decimals(wrapped_rebase_coins):
-    yield [i.decimals() for i in wrapped_rebase_coins]
 
 
 @pytest.fixture(scope="module")

--- a/tests/fixtures/accounts.py
+++ b/tests/fixtures/accounts.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def alice(accounts):
+    yield accounts[0]
+
+
+@pytest.fixture(scope="session")
+def bob(accounts):
+    yield accounts[1]
+
+
+@pytest.fixture(scope="session")
+def charlie(accounts):
+    yield accounts[2]
+
+
+@pytest.fixture(scope="session")
+def dave(accounts):
+    yield accounts[3]
+
+
+@pytest.fixture(scope="session")
+def fee_receiver(accounts):
+    yield accounts[4]

--- a/tests/fixtures/actions.py
+++ b/tests/fixtures/actions.py
@@ -1,0 +1,72 @@
+import pytest
+
+
+def _add_liquidity(acct, swap, coins, amounts):
+    swap.add_liquidity(amounts, 0, {"from": acct})
+
+
+def _mint(acct, wrapped_coins, wrapped_amounts, underlying_coins, underlying_amounts):
+    for coin, amount in zip(wrapped_coins, wrapped_amounts):
+        coin._mint_for_testing(acct, amount, {"from": acct})
+
+    for coin, amount in zip(underlying_coins[1:], underlying_amounts[1:]):
+        coin._mint_for_testing(acct, amount, {"from": acct})
+
+
+def _approve(owner, spender, *coins):
+    for coin in set(x for i in coins for x in i):
+        coin.approve(spender, 2 ** 256 - 1, {"from": owner})
+
+
+# pool setup fixtures
+
+
+@pytest.fixture()
+def add_initial_liquidity(
+    alice, mint_alice, approve_alice, underlying_coins, swap, initial_amounts
+):
+    # mint (10**7 * precision) of each coin in the pool
+    _add_liquidity(alice, swap, underlying_coins, initial_amounts)
+
+
+@pytest.fixture()
+def mint_bob(bob, underlying_coins, wrapped_coins, initial_amounts, initial_amounts_underlying):
+    _mint(bob, wrapped_coins, initial_amounts, underlying_coins, initial_amounts_underlying)
+
+
+@pytest.fixture(scope="module")
+def approve_bob(bob, swap, underlying_coins, wrapped_coins):
+    _approve(bob, swap, underlying_coins, wrapped_coins)
+
+
+@pytest.fixture()
+def mint_alice(alice, underlying_coins, wrapped_coins, initial_amounts, initial_amounts_underlying):
+    _mint(alice, wrapped_coins, initial_amounts, underlying_coins, initial_amounts_underlying)
+
+
+@pytest.fixture(scope="module")
+def approve_alice(alice, swap, underlying_coins, wrapped_coins):
+    _approve(alice, swap, underlying_coins, wrapped_coins)
+
+
+@pytest.fixture()
+def approve_zap(alice, bob, zap, swap, underlying_coins, initial_amounts_underlying):
+    for underlying, amount in zip(underlying_coins, initial_amounts_underlying):
+        if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
+            continue
+        underlying.approve(zap, 2 ** 256 - 1, {"from": alice})
+        underlying.approve(zap, 2 ** 256 - 1, {"from": bob})
+
+    swap.approve(zap, 2 ** 256 - 1, {"from": alice})
+    swap.approve(zap, 2 ** 256 - 1, {"from": bob})
+
+
+# Added for rebase tokens
+
+
+@pytest.fixture()
+def mint_and_deposit(wrapped_rebase_coins, wrapped_rebase_amounts, alice, swap_rebase):
+    for coin, amount in zip(wrapped_rebase_coins, wrapped_rebase_amounts):
+        coin._mint_for_testing(alice, amount, {"from": alice})
+        coin.approve(swap_rebase, amount, {"from": alice})
+    swap_rebase.add_liquidity(wrapped_rebase_amounts, 0, {"from": alice})

--- a/tests/fixtures/coins.py
+++ b/tests/fixtures/coins.py
@@ -1,0 +1,61 @@
+import pytest
+from brownie import ZERO_ADDRESS
+from brownie_tokens import ERC20, MintableForkToken
+
+
+@pytest.fixture(scope="module")
+def rebase_coin(alice, ATokenMock, AaveLendingPoolMock, ERC20Mock):
+    aave_lending_pool_mock = AaveLendingPoolMock.deploy({"from": alice})
+    erc20_mock = ERC20Mock.deploy("ERC20MOCK", "ERC", 18, {"from": alice})
+    yield ATokenMock.deploy(
+        "Rebase Mock", "MOK", 18, erc20_mock, aave_lending_pool_mock, {"from": alice}
+    )
+
+
+@pytest.fixture(scope="module")
+def wrapped_coins(is_rebase, coin, rebase_coin, base_lp_token):
+    if is_rebase:
+        yield [rebase_coin, base_lp_token]
+    else:
+        yield [coin, base_lp_token]
+
+
+@pytest.fixture(scope="module")
+def underlying_coins(coin, is_rebase, rebase_coin):
+    BASE_COINS = [
+        "0x6B175474E89094C44Da98b954EedeAC495271d0F",  # DAI
+        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # USDC
+        "0xdAC17F958D2ee523a2206206994597C13D831ec7",  # USDT
+    ]
+    if is_rebase:
+        yield [rebase_coin] + [MintableForkToken(i) for i in BASE_COINS]
+    else:
+        yield [coin] + [MintableForkToken(i) for i in BASE_COINS]
+
+
+@pytest.fixture(scope="module")
+def plain_coins():
+    yield [ERC20(decimals=7), ERC20(decimals=9), ZERO_ADDRESS, ZERO_ADDRESS]
+
+
+@pytest.fixture(scope="module")
+def base_lp_token():
+    yield MintableForkToken("0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490")
+
+
+@pytest.fixture(scope="module")
+def coin(pytestconfig):
+    yield ERC20(
+        decimals=pytestconfig.getoption("decimals"),
+        success=eval(pytestconfig.getoption("return_value")),
+    )
+
+
+@pytest.fixture(scope="module")
+def wrapped_rebase_coins(rebase_coin, base_lp_token):
+    yield [rebase_coin, base_lp_token]
+
+
+@pytest.fixture(scope="module")
+def wrapped_rebase_decimals(wrapped_rebase_coins):
+    yield [i.decimals() for i in wrapped_rebase_coins]

--- a/tests/fixtures/constants.py
+++ b/tests/fixtures/constants.py
@@ -1,0 +1,45 @@
+import pytest
+from brownie import ZERO_ADDRESS
+
+
+@pytest.fixture(scope="module", params=[0, 1])
+def is_rebase(request):
+    yield request.param
+
+
+@pytest.fixture(scope="module")
+def wrapped_decimals(wrapped_coins):
+    yield [i.decimals() if i != ZERO_ADDRESS else 0 for i in wrapped_coins]
+
+
+@pytest.fixture(scope="module")
+def plain_decimals(plain_coins):
+    yield [i.decimals() if i != ZERO_ADDRESS else 0 for i in plain_coins]
+
+
+@pytest.fixture(scope="module")
+def underlying_decimals(underlying_coins):
+    yield [i.decimals() for i in underlying_coins]
+
+
+@pytest.fixture(scope="module")
+def initial_amounts(wrapped_decimals, base_pool):
+    # 1e6 of each coin - used to make an even initial deposit in many test setups
+    amounts = [10 ** i * 1000000 for i in wrapped_decimals]
+    amounts[1] = amounts[1] * 10 ** 18 // base_pool.get_virtual_price()
+    yield amounts
+
+
+@pytest.fixture(scope="module")
+def initial_amounts_underlying(underlying_decimals):
+    # 1e6 of each coin - used to make an even initial deposit in many test setups
+    amounts = [10 ** i * 1000000 for i in underlying_decimals]
+    amounts[1:] = [i // 3 for i in amounts[1:]]
+    yield amounts
+
+
+@pytest.fixture(scope="module")
+def wrapped_rebase_amounts(base_pool, wrapped_coins, wrapped_decimals):
+    wrapped_amounts = [10 ** i * 1000000 for i in wrapped_decimals]
+    wrapped_amounts[1] = wrapped_amounts[1] * 10 ** 18 // base_pool.get_virtual_price()
+    yield wrapped_amounts

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -1,0 +1,137 @@
+import pytest
+from brownie import ZERO_ADDRESS, Contract
+from brownie_tokens import MintableForkToken
+
+
+@pytest.fixture(scope="module")
+def implementation_usd(MetaUSD, alice):
+    yield MetaUSD.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def implementation_btc(MetaBTC, alice):
+    yield MetaBTC.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def implementation_plain(Plain2Basic, alice):
+    yield Plain2Basic.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def implementation_rebase_btc(MetaBTCBalances, alice):
+    yield MetaBTCBalances.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def implementation_rebase_usd(MetaUSDBalances, alice):
+    yield MetaUSDBalances.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def factory(
+    Factory,
+    alice,
+    fee_receiver,
+    base_pool,
+    implementation_usd,
+    implementation_rebase_usd,
+    implementation_plain,
+):
+    contract = Factory.deploy({"from": alice})
+    contract.add_base_pool(
+        base_pool,
+        fee_receiver,
+        [implementation_usd, implementation_rebase_usd] + [ZERO_ADDRESS] * 8,
+        {"from": alice},
+    )
+    contract.set_plain_implementations(
+        2, [implementation_plain] + [ZERO_ADDRESS] * 9, {"from": alice}
+    )
+    yield contract
+
+
+@pytest.fixture()
+def new_factory(Factory, alice, fee_receiver, base_pool, implementation_usd):
+    contract = Factory.deploy({"from": alice})
+    yield contract
+
+
+@pytest.fixture(scope="module")
+def swap_plain(Plain2Basic, alice, factory, plain_coins):
+    tx = factory.deploy_plain_pool(
+        "Test Plain", "PLN", plain_coins, 200, 4000000, 0, {"from": alice}
+    )
+    yield Plain2Basic.at(tx.return_value)
+
+
+@pytest.fixture(scope="module")
+def swap(MetaUSD, MetaUSDBalances, is_rebase, alice, rebase_coin, base_pool, factory, coin):
+    if is_rebase:
+        tx = factory.deploy_metapool(
+            base_pool, "Test Swap", "TST", rebase_coin, 200, 4000000, 1, {"from": alice}
+        )
+        yield MetaUSDBalances.at(tx.return_value)
+    else:
+        tx = factory.deploy_metapool(
+            base_pool, "Test Swap", "TST", coin, 200, 4000000, 0, {"from": alice}
+        )
+        yield MetaUSD.at(tx.return_value)
+
+
+@pytest.fixture(scope="module")
+def swap_btc(MetaBTC, alice, base_pool_btc, factory, coin):
+    tx = factory.deploy_metapool(
+        base_pool_btc, "Test Swap BTC", "TSTB", coin, 200, 4000000, 0, {"from": alice}
+    )
+    yield MetaBTC.at(tx.return_value)
+
+
+@pytest.fixture(scope="module")
+def swap_rebase(MetaUSDBalances, alice, base_pool, factory, rebase_coin):
+    tx = factory.deploy_metapool(
+        base_pool, "Test Swap", "TST", rebase_coin, 200, 4000000, 1, {"from": alice}
+    )
+    yield MetaUSDBalances.at(tx.return_value)
+
+
+@pytest.fixture(scope="module")
+def swap_rebase_btc(MetaBTCBalances, alice, base_pool, factory, rebase_coin):
+    tx = factory.deploy_metapool(
+        base_pool, "Test Swap", "TST", rebase_coin, 200, 4000000, 1, {"from": alice}
+    )
+    yield MetaBTCBalances.at(tx.return_value)
+
+
+@pytest.fixture(scope="module")
+def zap(DepositZapUSD, alice):
+    yield DepositZapUSD.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def base_pool():
+    pool = Contract("0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7")
+
+    # ensure the base pool is balanced so our tests are deterministic
+    max_balance = max([pool.balances(0), pool.balances(1) * 10 ** 12, pool.balances(2) * 10 ** 12])
+    ideal_balances = [max_balance, max_balance // 10 ** 12, max_balance // 10 ** 12]
+    for i, amount in enumerate(ideal_balances):
+        balance = pool.balances(i)
+        if balance < amount:
+            MintableForkToken(pool.coins(i))._mint_for_testing(pool, amount - balance)
+    pool.donate_admin_fees({"from": pool.owner()})
+
+    yield pool
+
+
+@pytest.fixture(scope="module")
+def base_pool_btc(alice, fee_receiver, implementation_btc, factory, implementation_rebase_btc):
+    pool = Contract("0x7fC77b5c7614E1533320Ea6DDc2Eb61fa00A9714")
+    factory.add_base_pool(
+        pool,
+        fee_receiver,
+        [implementation_btc, implementation_rebase_btc] + [ZERO_ADDRESS] * 8,
+        {"from": alice},
+    )
+
+    yield pool

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -135,3 +135,8 @@ def base_pool_btc(alice, fee_receiver, implementation_btc, factory, implementati
     )
 
     yield pool
+
+
+@pytest.fixture(scope="module")
+def owner_proxy(alice, OwnerProxy):
+    return OwnerProxy.deploy(alice, alice, alice, {"from": alice})

--- a/tests/test_owner_proxy.py
+++ b/tests/test_owner_proxy.py
@@ -1,0 +1,156 @@
+import math
+
+import brownie
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+
+@pytest.fixture(autouse=True)
+def setup(alice, factory, owner_proxy):
+    factory.commit_transfer_ownership(owner_proxy, {"from": alice})
+    owner_proxy.accept_transfer_ownership(factory, {"from": alice})
+
+
+def test_commit_ownership_transfer(factory, owner_proxy, alice, bob):
+    owner_proxy.commit_transfer_ownership(factory, bob, {"from": alice})
+    assert factory.future_admin() == bob
+
+
+def test_only_ownership_admin_commit_ownership_transfer(factory, owner_proxy, bob):
+    with brownie.reverts("dev: admin only"):
+        owner_proxy.commit_transfer_ownership(factory, bob, {"from": bob})
+
+
+def test_accept_transfer_ownership(new_factory, alice, owner_proxy):
+    new_factory.commit_transfer_ownership(owner_proxy, {"from": alice})
+    owner_proxy.accept_transfer_ownership(new_factory, {"from": alice})
+    assert new_factory.admin() == owner_proxy
+
+
+def test_unguarded_accept_transfer_ownership(new_factory, alice, bob, owner_proxy):
+    new_factory.commit_transfer_ownership(owner_proxy, {"from": alice})
+    owner_proxy.accept_transfer_ownership(new_factory, {"from": bob})
+    assert new_factory.admin() == owner_proxy
+
+
+def test_set_fee_receiver(factory, alice, bob, owner_proxy):
+    # there is no input validation
+    owner_proxy.set_fee_receiver(factory, ZERO_ADDRESS, bob, {"from": alice})
+    assert factory.fee_receiver(ZERO_ADDRESS) == bob
+
+
+def test_set_fee_receiver_guarded(factory, bob, owner_proxy):
+    with brownie.reverts("Access denied"):
+        owner_proxy.set_fee_receiver(factory, ZERO_ADDRESS, bob, {"from": bob})
+
+
+def test_commit_new_admins(owner_proxy, alice, bob, charlie, dave):
+    owner_proxy.commit_set_admins(bob, charlie, dave, {"from": alice})
+    assert owner_proxy.future_ownership_admin() == bob
+    assert owner_proxy.future_parameter_admin() == charlie
+    assert owner_proxy.future_emergency_admin() == dave
+
+
+def test_guarded_commit_new_admins(owner_proxy, bob):
+    with brownie.reverts("Access denied"):
+        owner_proxy.commit_set_admins(bob, bob, bob, {"from": bob})
+
+
+def test_apply_set_admins(owner_proxy, alice, bob, charlie, dave):
+    owner_proxy.commit_set_admins(bob, charlie, dave, {"from": alice})
+    owner_proxy.apply_set_admins({"from": alice})
+    assert owner_proxy.ownership_admin() == bob
+    assert owner_proxy.parameter_admin() == charlie
+    assert owner_proxy.emergency_admin() == dave
+
+
+def test_apply_set_admins_guarded(owner_proxy, alice, bob, charlie, dave):
+    owner_proxy.commit_set_admins(bob, charlie, dave, {"from": alice})
+    with brownie.reverts("Access denied"):
+        owner_proxy.apply_set_admins({"from": bob})
+
+
+def test_ramp_A(owner_proxy, swap_plain, alice, chain):
+    future_a = swap_plain.A() * 1.5
+    future_time = chain.time() + 86400
+    A_PRECISION = 100
+    owner_proxy.ramp_A(swap_plain, future_a, future_time, {"from": alice})
+    assert swap_plain.future_A() / A_PRECISION == future_a
+    assert swap_plain.future_A_time() == future_time
+    chain.sleep(86400 + 1)
+
+
+def test_ramp_A_guarded(owner_proxy, swap_plain, bob):
+    with brownie.reverts("Access denied"):
+        owner_proxy.ramp_A(swap_plain, 0, 0, {"from": bob})
+
+
+def test_stop_ramp_A(owner_proxy, swap_plain, chain, alice):
+    future_a = swap_plain.A() * 2
+    future_time = chain.time() + 86400
+    owner_proxy.ramp_A(swap_plain, future_a, future_time, {"from": alice})
+
+    chain.sleep(86400 // 2)
+    owner_proxy.stop_ramp_A(swap_plain, {"from": alice})
+
+    assert math.isclose(swap_plain.A(), 3 * future_a / 4)
+
+
+def test_stop_ramp_A_guarded(owner_proxy, swap_plain, chain, alice, bob):
+    future_a = swap_plain.A() * 2
+    future_time = chain.time() + 86400
+    owner_proxy.ramp_A(swap_plain, future_a, future_time, {"from": alice})
+
+    chain.sleep(86400 // 2)
+    owner_proxy.stop_ramp_A(swap_plain, {"from": alice})
+
+    with brownie.reverts("Access denied"):
+        owner_proxy.stop_ramp_A(swap_plain, {"from": bob})
+
+
+def test_add_base_pool(owner_proxy, new_factory, base_pool_btc, implementation_btc, alice):
+    new_factory.commit_transfer_ownership(owner_proxy, {"from": alice})
+    owner_proxy.accept_transfer_ownership(new_factory, {"from": alice})
+
+    owner_proxy.add_base_pool(
+        new_factory,
+        base_pool_btc,
+        ETH_ADDRESS,
+        [implementation_btc] + [ZERO_ADDRESS] * 9,
+        {"from": alice},
+    )
+
+    assert new_factory.base_pool_list(0) == base_pool_btc
+
+
+def test_add_base_pool_guarded(owner_proxy, bob):
+    with brownie.reverts("Access denied"):
+        owner_proxy.add_base_pool(
+            ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS, [ZERO_ADDRESS] * 10, {"from": bob}
+        )
+
+
+def test_set_metapool_implementations(alice, owner_proxy, factory, base_pool_btc):
+    impls = [ETH_ADDRESS] + [ZERO_ADDRESS] * 9
+    owner_proxy.set_metapool_implementations(factory, base_pool_btc, impls, {"from": alice})
+    assert factory.metapool_implementations(base_pool_btc) == impls
+
+
+def test_set_metapool_implementations_guarded(bob, owner_proxy, factory, base_pool_btc):
+    impls = [ETH_ADDRESS] + [ZERO_ADDRESS] * 9
+    with brownie.reverts("Access denied"):
+        owner_proxy.set_metapool_implementations(factory, base_pool_btc, impls, {"from": bob})
+
+
+def test_set_plain_implementation(alice, owner_proxy, factory, implementation_plain):
+    owner_proxy.set_plain_implementations(
+        factory, 3, [implementation_plain] + [ZERO_ADDRESS] * 9, {"from": alice}
+    )
+    assert factory.plain_implementations(3, 0) == implementation_plain
+
+
+def test_set_plain_implementation_guarded(bob, owner_proxy, factory, implementation_plain):
+    with brownie.reverts("Access denied"):
+        owner_proxy.set_plain_implementations(
+            factory, 3, [implementation_plain] + [ZERO_ADDRESS] * 9, {"from": bob}
+        )


### PR DESCRIPTION
Started with the easy task first of testing the owner proxy contract.
Also split up the fixtures found in the `conftest.py` file into separate fixture files (only because it was too messy to look at).
Next step is to scrub the fixtures of all quirks and make sure the test suite behaves correctly with them before moving on to some more testing :)

OwnerProxy Coverage Output:
```bash
  contract: OwnerProxy - 100.0%
    OwnerProxy.accept_transfer_ownership - 100.0%
    OwnerProxy.add_base_pool - 100.0%
    OwnerProxy.apply_set_admins - 100.0%
    OwnerProxy.commit_set_admins - 100.0%
    OwnerProxy.commit_transfer_ownership - 100.0%
    OwnerProxy.ramp_A - 100.0%
    OwnerProxy.set_fee_receiver - 100.0%
    OwnerProxy.set_metapool_implementations - 100.0%
    OwnerProxy.set_plain_implementations - 100.0%
    OwnerProxy.stop_ramp_A - 100.0%
```


Also note, had to do a minor fix, the interface was incorrect when adding a base pool.