### PR TITLE
Add asset types

### DIFF
--- a/.github/workflows/owner-proxy.yaml
+++ b/.github/workflows/owner-proxy.yaml
@@ -1,0 +1,50 @@
+name: owner-proxy
+
+on:
+  pull_request:
+    paths:
+    - 'tests/test_owner_proxy.py'
+    - 'contracts/OwnerProxy.vy'
+  push:
+    paths:
+    - 'tests/test_owner_proxy.py'
+    - 'contracts/OwnerProxy.vy'
+
+env:
+  ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  WEB3_INFURA_PROJECT_ID: 4b7217c6901c42f2bd9e8509baa0699d
+  NODE_OPTIONS: --max_old_space_size=4096
+
+jobs:
+
+  unitary:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache Compiler Installations
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.solcx
+          ~/.vvm
+        key: compiler-cache
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+
+    - name: Install Ganache
+      run: npm install
+
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install Requirements
+      run: pip install -r requirements.txt
+
+    - name: Run Tests
+      run: brownie test tests/test_owner_proxy.py

--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -104,6 +104,7 @@ OLD_FACTORY: constant(address) = 0x0959158b6040D32d04c301A72CBFD6b39E21c9AE
 
 admin: public(address)
 future_admin: public(address)
+manager: public(address)
 
 pool_list: public(address[4294967296])   # master list of pools
 pool_count: public(uint256)              # actual length of pool_list
@@ -745,6 +746,21 @@ def set_plain_implementations(
                 break
         else:
             self.plain_implementations[_n_coins][i] = new_imp
+
+
+
+@external
+def batch_set_pool_asset_type(_pools: address[32], _asset_types: uint256[32]):
+    """
+    @notice Batch set the asset type for factory pools
+    @dev Used to modify asset types that were set incorrectly at deployment
+    """
+    assert msg.sender in [self.manager, self.admin]  # dev: admin-only function
+
+    for i in range(32):
+        if _pools[i] == ZERO_ADDRESS:
+            break
+        self.pool_data[_pools[i]].asset_type = _asset_types[i]
 
 
 @external

--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -788,6 +788,18 @@ def accept_transfer_ownership():
 
 
 @external
+def set_manager(_manager: address):
+    """
+    @notice Set the manager
+    @dev Callable by the admin or existing manager
+    @param _manager Manager address
+    """
+    assert msg.sender in [self.manager, self.admin]  # dev: admin-only function
+
+    self.manager = _manager
+
+
+@external
 def set_fee_receiver(_pool: address, _fee_receiver: address):
     """
     @notice Set fee receiver for base and plain pools

--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -12,6 +12,7 @@ struct PoolArray:
     coins: address[MAX_PLAIN_COINS]
     decimals: uint256[MAX_PLAIN_COINS]
     n_coins: uint256
+    asset_type: uint256
 
 struct BasePoolArray:
     implementations: address[10]
@@ -19,6 +20,7 @@ struct BasePoolArray:
     coins: address[MAX_COINS]
     decimals: uint256
     n_coins: uint256
+    asset_type: uint256
 
 
 interface AddressProvider:
@@ -458,8 +460,23 @@ def is_meta(_pool: address) -> bool:
     return self.pool_data[_pool].base_pool != ZERO_ADDRESS
 
 
-# <--- Pool Deployers --->
+@view
+@external
+def get_pool_asset_type(_pool: address) -> uint256:
+    """
+    @notice Query the asset type of `_pool`
+    @dev 0 = USD, 1 = ETH, 2 = BTC, 3 = Other
+    @param _pool Pool Address
+    @return Integer indicating the pool asset type
+    """
+    base_pool: address = self.pool_data[_pool].base_pool
+    if base_pool == ZERO_ADDRESS:
+        return self.pool_data[_pool].asset_type
+    else:
+        return self.base_pool_data[base_pool].asset_type
 
+
+# <--- Pool Deployers --->
 
 @external
 def deploy_plain_pool(
@@ -468,6 +485,7 @@ def deploy_plain_pool(
     _coins: address[MAX_PLAIN_COINS],
     _A: uint256,
     _fee: uint256,
+    _asset_type: uint256 = 0,
     _implementation_idx: uint256 = 0,
 ) -> address:
     """
@@ -485,6 +503,8 @@ def deploy_plain_pool(
     @param _fee Trade fee, given as an integer with 1e10 precision. The
                 minimum fee is 0.04% (4000000), the maximum is 1% (100000000).
                 50% of the fee is distributed to veCRV holders.
+    @param _asset_type Asset type for pool, as an integer
+                       0 = USD, 1 = ETH, 2 = BTC, 3 = Other
     @param _implementation_idx Index of the implementation to use. All possible
                 implementations for a pool of N_COINS can be publicly accessed
                 via `plain_implementations(N_COINS)`
@@ -533,6 +553,8 @@ def deploy_plain_pool(
     self.pool_data[pool].n_coins = n_coins
     self.pool_data[pool].base_pool = ZERO_ADDRESS
     self.pool_data[pool].implementation = implementation
+    if _asset_type != 0:
+        self.pool_data[pool].asset_type = _asset_type
 
     for i in range(MAX_PLAIN_COINS):
         coin: address = _coins[i]
@@ -636,6 +658,7 @@ def deploy_metapool(
 def add_base_pool(
     _base_pool: address,
     _fee_receiver: address,
+    _asset_type: uint256,
     _implementations: address[10],
 ):
     """
@@ -643,6 +666,7 @@ def add_base_pool(
     @dev Only callable by admin
     @param _base_pool Pool address to add
     @param _fee_receiver Admin fee receiver address for metapools using this base pool
+    @param _asset_type Asset type for pool, as an integer  0 = USD, 1 = ETH, 2 = BTC, 3 = Other
     @param _implementations List of implementation addresses that can be used with this base pool
     """
     assert msg.sender == self.admin  # dev: admin-only function
@@ -657,6 +681,8 @@ def add_base_pool(
     self.base_pool_count = length + 1
     self.base_pool_data[_base_pool].lp_token = Registry(registry).get_lp_token(_base_pool)
     self.base_pool_data[_base_pool].n_coins = n_coins
+    if _asset_type != 0:
+        self.base_pool_data[_base_pool].asset_type = _asset_type
 
     for i in range(10):
         implementation: address = _implementations[i]
@@ -781,7 +807,7 @@ def add_existing_metapools(_pools: address[10]) -> bool:
     """
     @notice Add existing metapools from the old factory
     @dev Base pools that are used by the pools to be added must
-         be added separately with `add_base_pool`.
+         be added separately with `add_base_pool`
     @param _pools Addresses of existing pools to add
     """
 

--- a/contracts/LiquidityGaugeV3.vy
+++ b/contracts/LiquidityGaugeV3.vy
@@ -1,0 +1,776 @@
+# @version 0.2.12
+"""
+@title Liquidity Gauge v3
+@author Curve Finance
+@license MIT
+"""
+
+from vyper.interfaces import ERC20
+
+implements: ERC20
+
+
+interface CRV20:
+    def future_epoch_time_write() -> uint256: nonpayable
+    def rate() -> uint256: view
+
+interface Controller:
+    def period() -> int128: view
+    def period_write() -> int128: nonpayable
+    def period_timestamp(p: int128) -> uint256: view
+    def gauge_relative_weight(addr: address, time: uint256) -> uint256: view
+    def voting_escrow() -> address: view
+    def checkpoint(): nonpayable
+    def checkpoint_gauge(addr: address): nonpayable
+
+interface Minter:
+    def token() -> address: view
+    def controller() -> address: view
+    def minted(user: address, gauge: address) -> uint256: view
+
+interface VotingEscrow:
+    def user_point_epoch(addr: address) -> uint256: view
+    def user_point_history__ts(addr: address, epoch: uint256) -> uint256: view
+
+interface ERC20Extended:
+    def symbol() -> String[26]: view
+
+interface Factory:
+    def admin() -> address: view
+
+
+event Deposit:
+    provider: indexed(address)
+    value: uint256
+
+event Withdraw:
+    provider: indexed(address)
+    value: uint256
+
+event UpdateLiquidityLimit:
+    user: address
+    original_balance: uint256
+    original_supply: uint256
+    working_balance: uint256
+    working_supply: uint256
+
+event CommitOwnership:
+    admin: address
+
+event ApplyOwnership:
+    admin: address
+
+event Transfer:
+    _from: indexed(address)
+    _to: indexed(address)
+    _value: uint256
+
+event Approval:
+    _owner: indexed(address)
+    _spender: indexed(address)
+    _value: uint256
+
+
+MAX_REWARDS: constant(uint256) = 8
+TOKENLESS_PRODUCTION: constant(uint256) = 40
+WEEK: constant(uint256) = 604800
+CLAIM_FREQUENCY: constant(uint256) = 3600
+
+MINTER: constant(address) = 0xd061D61a4d941c39E5453435B6345Dc261C2fcE0
+CRV: constant(address) = 0xD533a949740bb3306d119CC777fa900bA034cd52
+VOTING_ESCROW: constant(address) = 0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2
+GAUGE_CONTROLLER: constant(address) = 0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB
+
+
+lp_token: public(address)
+future_epoch_time: public(uint256)
+
+balanceOf: public(HashMap[address, uint256])
+totalSupply: public(uint256)
+allowance: public(HashMap[address, HashMap[address, uint256]])
+
+name: public(String[64])
+symbol: public(String[32])
+
+working_balances: public(HashMap[address, uint256])
+working_supply: public(uint256)
+
+# The goal is to be able to calculate ∫(rate * balance / totalSupply dt) from 0 till checkpoint
+# All values are kept in units of being multiplied by 1e18
+period: public(int128)
+period_timestamp: public(uint256[100000000000000000000000000000])
+
+# 1e18 * ∫(rate(t) / totalSupply(t) dt) from 0 till checkpoint
+integrate_inv_supply: public(uint256[100000000000000000000000000000])  # bump epoch when rate() changes
+
+# 1e18 * ∫(rate(t) / totalSupply(t) dt) from (last_action) till checkpoint
+integrate_inv_supply_of: public(HashMap[address, uint256])
+integrate_checkpoint_of: public(HashMap[address, uint256])
+
+# ∫(balance * rate(t) / totalSupply(t) dt) from 0 till checkpoint
+# Units: rate * t = already number of coins per address to issue
+integrate_fraction: public(HashMap[address, uint256])
+
+inflation_rate: public(uint256)
+
+# For tracking external rewards
+reward_data: uint256
+reward_tokens: public(address[MAX_REWARDS])
+
+# deposit / withdraw / claim
+reward_sigs: bytes32
+
+# claimant -> default reward receiver
+rewards_receiver: public(HashMap[address, address])
+
+# reward token -> integral
+reward_integral: public(HashMap[address, uint256])
+
+# reward token -> claiming address -> integral
+reward_integral_for: public(HashMap[address, HashMap[address, uint256]])
+
+# user -> [uint128 claimable amount][uint128 claimed amount]
+claim_data: HashMap[address, HashMap[address, uint256]]
+
+is_killed: public(bool)
+factory: public(address)
+
+
+@external
+def __init__():
+    self.lp_token = 0x000000000000000000000000000000000000dEaD
+
+
+@external
+def initialize(_lp_token: address):
+    """
+    @notice Contract constructor
+    @param _lp_token Liquidity Pool contract address
+    """
+
+    assert self.lp_token == ZERO_ADDRESS
+    self.lp_token = _lp_token
+    self.factory = msg.sender
+
+    symbol: String[26] = ERC20Extended(_lp_token).symbol()
+    self.name = concat("Curve.fi ", symbol, " Gauge Deposit")
+    self.symbol = concat(symbol, "-gauge")
+
+    self.period_timestamp[0] = block.timestamp
+    self.inflation_rate = CRV20(CRV).rate()
+    self.future_epoch_time = CRV20(CRV).future_epoch_time_write()
+
+
+@view
+@external
+def decimals() -> uint256:
+    """
+    @notice Get the number of decimals for this token
+    @dev Implemented as a view method to reduce gas costs
+    @return uint256 decimal places
+    """
+    return 18
+
+
+@view
+@external
+def integrate_checkpoint() -> uint256:
+    return self.period_timestamp[self.period]
+
+
+@internal
+def _update_liquidity_limit(addr: address, l: uint256, L: uint256):
+    """
+    @notice Calculate limits which depend on the amount of CRV token per-user.
+            Effectively it calculates working balances to apply amplification
+            of CRV production by CRV
+    @param addr User address
+    @param l User's amount of liquidity (LP tokens)
+    @param L Total amount of liquidity (LP tokens)
+    """
+    # To be called after totalSupply is updated
+    voting_balance: uint256 = ERC20(VOTING_ESCROW).balanceOf(addr)
+    voting_total: uint256 = ERC20(VOTING_ESCROW).totalSupply()
+
+    lim: uint256 = l * TOKENLESS_PRODUCTION / 100
+    if voting_total > 0:
+        lim += L * voting_balance / voting_total * (100 - TOKENLESS_PRODUCTION) / 100
+
+    lim = min(l, lim)
+    old_bal: uint256 = self.working_balances[addr]
+    self.working_balances[addr] = lim
+    _working_supply: uint256 = self.working_supply + lim - old_bal
+    self.working_supply = _working_supply
+
+    log UpdateLiquidityLimit(addr, l, L, lim, _working_supply)
+
+
+@internal
+def _checkpoint_rewards( _user: address, _total_supply: uint256, _claim: bool, _receiver: address):
+    """
+    @notice Claim pending rewards and checkpoint rewards for a user
+    """
+    # load reward tokens and integrals into memory
+    reward_tokens: address[MAX_REWARDS] = empty(address[MAX_REWARDS])
+    reward_integrals: uint256[MAX_REWARDS] = empty(uint256[MAX_REWARDS])
+    for i in range(MAX_REWARDS):
+        token: address = self.reward_tokens[i]
+        if token == ZERO_ADDRESS:
+            break
+        reward_tokens[i] = token
+        reward_integrals[i] = self.reward_integral[token]
+
+    reward_data: uint256 = self.reward_data
+    if _total_supply != 0 and reward_data != 0 and block.timestamp > shift(reward_data, -160) + CLAIM_FREQUENCY:
+        # track balances prior to claiming
+        reward_balances: uint256[MAX_REWARDS] = empty(uint256[MAX_REWARDS])
+        for i in range(MAX_REWARDS):
+            token: address = self.reward_tokens[i]
+            if token == ZERO_ADDRESS:
+                break
+            reward_balances[i] = ERC20(token).balanceOf(self)
+
+        # claim from reward contract
+        reward_contract: address = convert(reward_data % 2**160, address)
+        raw_call(reward_contract, slice(self.reward_sigs, 8, 4))  # dev: bad claim sig
+        self.reward_data = convert(reward_contract, uint256) + shift(block.timestamp, 160)
+
+        # get balances after claim and calculate new reward integrals
+        for i in range(MAX_REWARDS):
+            token: address = reward_tokens[i]
+            if token == ZERO_ADDRESS:
+                break
+            dI: uint256 = 10**18 * (ERC20(token).balanceOf(self) - reward_balances[i]) / _total_supply
+            if dI > 0:
+                reward_integrals[i] += dI
+                self.reward_integral[token] = reward_integrals[i]
+
+    if _user != ZERO_ADDRESS:
+        user_balance: uint256 = self.balanceOf[_user]
+        receiver: address = _receiver
+        if _claim and _receiver == ZERO_ADDRESS:
+            # if receiver is not explicitly declared, check if a default receiver is set
+            receiver = self.rewards_receiver[_user]
+            if receiver == ZERO_ADDRESS:
+                # if no default receiver is set, direct claims to the user
+                receiver = _user
+
+        # calculate new user reward integral and transfer any owed rewards
+        for i in range(MAX_REWARDS):
+            token: address = reward_tokens[i]
+            if token == ZERO_ADDRESS:
+                break
+
+            integral: uint256 = reward_integrals[i]
+            integral_for: uint256 = self.reward_integral_for[token][_user]
+            new_claimable: uint256 = 0
+            if integral_for < integral:
+                self.reward_integral_for[token][_user] = integral
+                new_claimable = user_balance * (integral - integral_for) / 10**18
+
+            claim_data: uint256 = self.claim_data[_user][token]
+            total_claimable: uint256 = shift(claim_data, -128) + new_claimable
+            if total_claimable > 0:
+                total_claimed: uint256 = claim_data % 2**128
+                if _claim:
+                    response: Bytes[32] = raw_call(
+                        token,
+                        concat(
+                            method_id("transfer(address,uint256)"),
+                            convert(receiver, bytes32),
+                            convert(total_claimable, bytes32),
+                        ),
+                        max_outsize=32,
+                    )
+                    if len(response) != 0:
+                        assert convert(response, bool)
+                    self.claim_data[_user][token] = total_claimed + total_claimable
+                elif new_claimable > 0:
+                    self.claim_data[_user][token] = total_claimed + shift(total_claimable, 128)
+
+
+@internal
+def _checkpoint(addr: address):
+    """
+    @notice Checkpoint for a user
+    @param addr User address
+    """
+    _period: int128 = self.period
+    _period_time: uint256 = self.period_timestamp[_period]
+    _integrate_inv_supply: uint256 = self.integrate_inv_supply[_period]
+    rate: uint256 = self.inflation_rate
+    new_rate: uint256 = rate
+    prev_future_epoch: uint256 = self.future_epoch_time
+    if prev_future_epoch >= _period_time:
+        self.future_epoch_time = CRV20(CRV).future_epoch_time_write()
+        new_rate = CRV20(CRV).rate()
+        self.inflation_rate = new_rate
+
+    if self.is_killed:
+        # Stop distributing inflation as soon as killed
+        rate = 0
+
+    # Update integral of 1/supply
+    if block.timestamp > _period_time:
+        _working_supply: uint256 = self.working_supply
+        Controller(GAUGE_CONTROLLER).checkpoint_gauge(self)
+        prev_week_time: uint256 = _period_time
+        week_time: uint256 = min((_period_time + WEEK) / WEEK * WEEK, block.timestamp)
+
+        for i in range(500):
+            dt: uint256 = week_time - prev_week_time
+            w: uint256 = Controller(GAUGE_CONTROLLER).gauge_relative_weight(self, prev_week_time / WEEK * WEEK)
+
+            if _working_supply > 0:
+                if prev_future_epoch >= prev_week_time and prev_future_epoch < week_time:
+                    # If we went across one or multiple epochs, apply the rate
+                    # of the first epoch until it ends, and then the rate of
+                    # the last epoch.
+                    # If more than one epoch is crossed - the gauge gets less,
+                    # but that'd meen it wasn't called for more than 1 year
+                    _integrate_inv_supply += rate * w * (prev_future_epoch - prev_week_time) / _working_supply
+                    rate = new_rate
+                    _integrate_inv_supply += rate * w * (week_time - prev_future_epoch) / _working_supply
+                else:
+                    _integrate_inv_supply += rate * w * dt / _working_supply
+                # On precisions of the calculation
+                # rate ~= 10e18
+                # last_weight > 0.01 * 1e18 = 1e16 (if pool weight is 1%)
+                # _working_supply ~= TVL * 1e18 ~= 1e26 ($100M for example)
+                # The largest loss is at dt = 1
+                # Loss is 1e-9 - acceptable
+
+            if week_time == block.timestamp:
+                break
+            prev_week_time = week_time
+            week_time = min(week_time + WEEK, block.timestamp)
+
+    _period += 1
+    self.period = _period
+    self.period_timestamp[_period] = block.timestamp
+    self.integrate_inv_supply[_period] = _integrate_inv_supply
+
+    # Update user-specific integrals
+    _working_balance: uint256 = self.working_balances[addr]
+    self.integrate_fraction[addr] += _working_balance * (_integrate_inv_supply - self.integrate_inv_supply_of[addr]) / 10 ** 18
+    self.integrate_inv_supply_of[addr] = _integrate_inv_supply
+    self.integrate_checkpoint_of[addr] = block.timestamp
+
+
+@external
+def user_checkpoint(addr: address) -> bool:
+    """
+    @notice Record a checkpoint for `addr`
+    @param addr User address
+    @return bool success
+    """
+    assert msg.sender in [addr, MINTER]  # dev: unauthorized
+    self._checkpoint(addr)
+    self._update_liquidity_limit(addr, self.balanceOf[addr], self.totalSupply)
+    return True
+
+
+@external
+def claimable_tokens(addr: address) -> uint256:
+    """
+    @notice Get the number of claimable tokens per user
+    @dev This function should be manually changed to "view" in the ABI
+    @return uint256 number of claimable tokens per user
+    """
+    self._checkpoint(addr)
+    return self.integrate_fraction[addr] - Minter(MINTER).minted(addr, self)
+
+
+@view
+@external
+def reward_contract() -> address:
+    """
+    @notice Address of the reward contract providing non-CRV incentives for this gauge
+    @dev Returns `ZERO_ADDRESS` if there is no reward contract active
+    """
+    return convert(self.reward_data % 2**160, address)
+
+
+@view
+@external
+def last_claim() -> uint256:
+    """
+    @notice Epoch timestamp of the last call to claim from `reward_contract`
+    @dev Rewards are claimed at most once per hour in order to reduce gas costs
+    """
+    return shift(self.reward_data, -160)
+
+
+@view
+@external
+def claimed_reward(_addr: address, _token: address) -> uint256:
+    """
+    @notice Get the number of already-claimed reward tokens for a user
+    @param _addr Account to get reward amount for
+    @param _token Token to get reward amount for
+    @return uint256 Total amount of `_token` already claimed by `_addr`
+    """
+    return self.claim_data[_addr][_token] % 2**128
+
+
+@view
+@external
+def claimable_reward(_addr: address, _token: address) -> uint256:
+    """
+    @notice Get the number of claimable reward tokens for a user
+    @dev This call does not consider pending claimable amount in `reward_contract`.
+         Off-chain callers should instead use `claimable_rewards_write` as a
+         view method.
+    @param _addr Account to get reward amount for
+    @param _token Token to get reward amount for
+    @return uint256 Claimable reward token amount
+    """
+    return shift(self.claim_data[_addr][_token], -128)
+
+
+@external
+@nonreentrant('lock')
+def claimable_reward_write(_addr: address, _token: address) -> uint256:
+    """
+    @notice Get the number of claimable reward tokens for a user
+    @dev This function should be manually changed to "view" in the ABI
+         Calling it via a transaction will claim available reward tokens
+    @param _addr Account to get reward amount for
+    @param _token Token to get reward amount for
+    @return uint256 Claimable reward token amount
+    """
+    if self.reward_tokens[0] != ZERO_ADDRESS:
+        self._checkpoint_rewards(_addr, self.totalSupply, False, ZERO_ADDRESS)
+    return shift(self.claim_data[_addr][_token], -128)
+
+
+@external
+def set_rewards_receiver(_receiver: address):
+    """
+    @notice Set the default reward receiver for the caller.
+    @dev When set to ZERO_ADDRESS, rewards are sent to the caller
+    @param _receiver Receiver address for any rewards claimed via `claim_rewards`
+    """
+    self.rewards_receiver[msg.sender] = _receiver
+
+
+@external
+@nonreentrant('lock')
+def claim_rewards(_addr: address = msg.sender, _receiver: address = ZERO_ADDRESS):
+    """
+    @notice Claim available reward tokens for `_addr`
+    @param _addr Address to claim for
+    @param _receiver Address to transfer rewards to - if set to
+                     ZERO_ADDRESS, uses the default reward receiver
+                     for the caller
+    """
+    if _receiver != ZERO_ADDRESS:
+        assert _addr == msg.sender  # dev: cannot redirect when claiming for another user
+    self._checkpoint_rewards(_addr, self.totalSupply, True, _receiver)
+
+
+@external
+def kick(addr: address):
+    """
+    @notice Kick `addr` for abusing their boost
+    @dev Only if either they had another voting event, or their voting escrow lock expired
+    @param addr Address to kick
+    """
+    t_last: uint256 = self.integrate_checkpoint_of[addr]
+    t_ve: uint256 = VotingEscrow(VOTING_ESCROW).user_point_history__ts(
+        addr, VotingEscrow(VOTING_ESCROW).user_point_epoch(addr)
+    )
+    _balance: uint256 = self.balanceOf[addr]
+
+    assert ERC20(VOTING_ESCROW).balanceOf(addr) == 0 or t_ve > t_last # dev: kick not allowed
+    assert self.working_balances[addr] > _balance * TOKENLESS_PRODUCTION / 100  # dev: kick not needed
+
+    self._checkpoint(addr)
+    self._update_liquidity_limit(addr, self.balanceOf[addr], self.totalSupply)
+
+
+@external
+@nonreentrant('lock')
+def deposit(_value: uint256, _addr: address = msg.sender, _claim_rewards: bool = False):
+    """
+    @notice Deposit `_value` LP tokens
+    @dev Depositting also claims pending reward tokens
+    @param _value Number of tokens to deposit
+    @param _addr Address to deposit for
+    """
+
+    self._checkpoint(_addr)
+
+    if _value != 0:
+        is_rewards: bool = self.reward_tokens[0] != ZERO_ADDRESS
+        total_supply: uint256 = self.totalSupply
+        if is_rewards:
+            self._checkpoint_rewards(_addr, total_supply, _claim_rewards, ZERO_ADDRESS)
+
+        total_supply += _value
+        new_balance: uint256 = self.balanceOf[_addr] + _value
+        self.balanceOf[_addr] = new_balance
+        self.totalSupply = total_supply
+
+        self._update_liquidity_limit(_addr, new_balance, total_supply)
+
+        ERC20(self.lp_token).transferFrom(msg.sender, self, _value)
+        if is_rewards:
+            reward_data: uint256 = self.reward_data
+            if reward_data > 0:
+                deposit_sig: Bytes[4] = slice(self.reward_sigs, 0, 4)
+                if convert(deposit_sig, uint256) != 0:
+                    raw_call(
+                        convert(reward_data % 2**160, address),
+                        concat(deposit_sig, convert(_value, bytes32))
+                    )
+
+    log Deposit(_addr, _value)
+    log Transfer(ZERO_ADDRESS, _addr, _value)
+
+
+@external
+@nonreentrant('lock')
+def withdraw(_value: uint256, _claim_rewards: bool = False):
+    """
+    @notice Withdraw `_value` LP tokens
+    @dev Withdrawing also claims pending reward tokens
+    @param _value Number of tokens to withdraw
+    """
+    self._checkpoint(msg.sender)
+
+    if _value != 0:
+        is_rewards: bool = self.reward_tokens[0] != ZERO_ADDRESS
+        total_supply: uint256 = self.totalSupply
+        if is_rewards:
+            self._checkpoint_rewards(msg.sender, total_supply, _claim_rewards, ZERO_ADDRESS)
+
+        total_supply -= _value
+        new_balance: uint256 = self.balanceOf[msg.sender] - _value
+        self.balanceOf[msg.sender] = new_balance
+        self.totalSupply = total_supply
+
+        self._update_liquidity_limit(msg.sender, new_balance, total_supply)
+
+        if is_rewards:
+            reward_data: uint256 = self.reward_data
+            if reward_data > 0:
+                withdraw_sig: Bytes[4] = slice(self.reward_sigs, 4, 4)
+                if convert(withdraw_sig, uint256) != 0:
+                    raw_call(
+                        convert(reward_data % 2**160, address),
+                        concat(withdraw_sig, convert(_value, bytes32))
+                    )
+        ERC20(self.lp_token).transfer(msg.sender, _value)
+
+    log Withdraw(msg.sender, _value)
+    log Transfer(msg.sender, ZERO_ADDRESS, _value)
+
+
+@internal
+def _transfer(_from: address, _to: address, _value: uint256):
+    self._checkpoint(_from)
+    self._checkpoint(_to)
+
+    if _value != 0:
+        total_supply: uint256 = self.totalSupply
+        is_rewards: bool = self.reward_tokens[0] != ZERO_ADDRESS
+        if is_rewards:
+            self._checkpoint_rewards(_from, total_supply, False, ZERO_ADDRESS)
+        new_balance: uint256 = self.balanceOf[_from] - _value
+        self.balanceOf[_from] = new_balance
+        self._update_liquidity_limit(_from, new_balance, total_supply)
+
+        if is_rewards:
+            self._checkpoint_rewards(_to, total_supply, False, ZERO_ADDRESS)
+        new_balance = self.balanceOf[_to] + _value
+        self.balanceOf[_to] = new_balance
+        self._update_liquidity_limit(_to, new_balance, total_supply)
+
+    log Transfer(_from, _to, _value)
+
+
+@external
+@nonreentrant('lock')
+def transfer(_to : address, _value : uint256) -> bool:
+    """
+    @notice Transfer token for a specified address
+    @dev Transferring claims pending reward tokens for the sender and receiver
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    self._transfer(msg.sender, _to, _value)
+
+    return True
+
+
+@external
+@nonreentrant('lock')
+def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    """
+     @notice Transfer tokens from one address to another.
+     @dev Transferring claims pending reward tokens for the sender and receiver
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    _allowance: uint256 = self.allowance[_from][msg.sender]
+    if _allowance != MAX_UINT256:
+        self.allowance[_from][msg.sender] = _allowance - _value
+
+    self._transfer(_from, _to, _value)
+
+    return True
+
+
+@external
+def approve(_spender : address, _value : uint256) -> bool:
+    """
+    @notice Approve the passed address to transfer the specified amount of
+            tokens on behalf of msg.sender
+    @dev Beware that changing an allowance via this method brings the risk
+         that someone may use both the old and new allowance by unfortunate
+         transaction ordering. This may be mitigated with the use of
+         {incraseAllowance} and {decreaseAllowance}.
+         https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will transfer the funds
+    @param _value The amount of tokens that may be transferred
+    @return bool success
+    """
+    self.allowance[msg.sender][_spender] = _value
+    log Approval(msg.sender, _spender, _value)
+
+    return True
+
+
+@external
+def increaseAllowance(_spender: address, _added_value: uint256) -> bool:
+    """
+    @notice Increase the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _added_value The amount of to increase the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowance[msg.sender][_spender] + _added_value
+    self.allowance[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
+    """
+    @notice Decrease the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _subtracted_value The amount of to decrease the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowance[msg.sender][_spender] - _subtracted_value
+    self.allowance[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+@nonreentrant('lock')
+def set_rewards(_reward_contract: address, _sigs: bytes32, _reward_tokens: address[MAX_REWARDS]):
+    """
+    @notice Set the active reward contract
+    @dev A reward contract cannot be set while this contract has no deposits
+    @param _reward_contract Reward contract address. Set to ZERO_ADDRESS to
+                            disable staking.
+    @param _sigs Four byte selectors for staking, withdrawing and claiming,
+                 right padded with zero bytes. If the reward contract can
+                 be claimed from but does not require staking, the staking
+                 and withdraw selectors should be set to 0x00
+    @param _reward_tokens List of claimable reward tokens. New reward tokens
+                          may be added but they cannot be removed. When calling
+                          this function to unset or modify a reward contract,
+                          this array must begin with the already-set reward
+                          token addresses.
+    """
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
+
+    lp_token: address = self.lp_token
+    current_reward_contract: address = convert(self.reward_data % 2**160, address)
+    total_supply: uint256 = self.totalSupply
+    if self.reward_tokens[0] != ZERO_ADDRESS:
+        self._checkpoint_rewards(ZERO_ADDRESS, total_supply, False, ZERO_ADDRESS)
+    if current_reward_contract != ZERO_ADDRESS:
+        withdraw_sig: Bytes[4] = slice(self.reward_sigs, 4, 4)
+        if convert(withdraw_sig, uint256) != 0:
+            if total_supply != 0:
+                raw_call(
+                    current_reward_contract,
+                    concat(withdraw_sig, convert(total_supply, bytes32))
+                )
+            ERC20(lp_token).approve(current_reward_contract, 0)
+
+    if _reward_contract != ZERO_ADDRESS:
+        assert _reward_tokens[0] != ZERO_ADDRESS  # dev: no reward token
+        assert _reward_contract.is_contract  # dev: not a contract
+        deposit_sig: Bytes[4] = slice(_sigs, 0, 4)
+        withdraw_sig: Bytes[4] = slice(_sigs, 4, 4)
+
+        if convert(deposit_sig, uint256) != 0:
+            # need a non-zero total supply to verify the sigs
+            assert total_supply != 0  # dev: zero total supply
+            ERC20(lp_token).approve(_reward_contract, MAX_UINT256)
+
+            # it would be Very Bad if we get the signatures wrong here, so
+            # we do a test deposit and withdrawal prior to setting them
+            raw_call(
+                _reward_contract,
+                concat(deposit_sig, convert(total_supply, bytes32))
+            )  # dev: failed deposit
+            assert ERC20(lp_token).balanceOf(self) == 0
+            raw_call(
+                _reward_contract,
+                concat(withdraw_sig, convert(total_supply, bytes32))
+            )  # dev: failed withdraw
+            assert ERC20(lp_token).balanceOf(self) == total_supply
+
+            # deposit and withdraw are good, time to make the actual deposit
+            raw_call(
+                _reward_contract,
+                concat(deposit_sig, convert(total_supply, bytes32))
+            )
+        else:
+            assert convert(withdraw_sig, uint256) == 0  # dev: withdraw without deposit
+
+    self.reward_data = convert(_reward_contract, uint256)
+    self.reward_sigs = _sigs
+    for i in range(MAX_REWARDS):
+        current_token: address = self.reward_tokens[i]
+        new_token: address = _reward_tokens[i]
+        if current_token != ZERO_ADDRESS:
+            assert current_token == new_token  # dev: cannot modify existing reward token
+        elif new_token != ZERO_ADDRESS:
+            # store new reward token
+            self.reward_tokens[i] = new_token
+        else:
+            break
+
+    if _reward_contract != ZERO_ADDRESS:
+        # do an initial checkpoint to verify that claims are working
+        self._checkpoint_rewards(ZERO_ADDRESS, total_supply, False, ZERO_ADDRESS)
+
+
+@external
+def set_killed(_is_killed: bool):
+    """
+    @notice Set the killed status for this contract
+    @dev When killed, the gauge always yields a rate of 0 and so cannot mint CRV
+    @param _is_killed Killed status to set
+    """
+    assert msg.sender == Factory(self.factory).admin()  # dev: only owner
+
+    self.is_killed = _is_killed

--- a/contracts/OwnerProxy.vy
+++ b/contracts/OwnerProxy.vy
@@ -28,6 +28,7 @@ interface Factory:
     def set_fee_receiver(_base_pool: address, _fee_receiver: address): nonpayable
     def commit_transfer_ownership(addr: address): nonpayable
     def accept_transfer_ownership(): nonpayable
+    def set_manager(_manager: address): nonpayable
 
 
 event CommitAdmins:
@@ -162,6 +163,12 @@ def set_plain_implementations(
 def set_fee_receiver(_target: address, _base_pool: address, _fee_receiver: address):
     assert msg.sender == self.ownership_admin, "Access denied"
     Factory(_target).set_fee_receiver(_base_pool, _fee_receiver)
+
+
+@external
+def set_manager(_target: address, _manager: address):
+    assert msg.sender == self.ownership_admin, "Access denied"
+    Factory(_target).set_manager(_manager)
 
 
 @external

--- a/contracts/OwnerProxy.vy
+++ b/contracts/OwnerProxy.vy
@@ -14,6 +14,7 @@ interface Factory:
     def add_base_pool(
         _base_pool: address,
         _fee_receiver: address,
+        _asset_type: uint256,
         _implementations: address[10],
     ): nonpayable
     def set_metapool_implementations(
@@ -122,12 +123,13 @@ def add_base_pool(
     _target: address,
     _base_pool: address,
     _fee_receiver: address,
+    _asset_type: uint256,
     _implementations: address[10],
 ):
 
     assert msg.sender == self.ownership_admin, "Access denied"
 
-    Factory(_target).add_base_pool(_base_pool, _fee_receiver, _implementations)
+    Factory(_target).add_base_pool(_base_pool, _fee_receiver, _asset_type, _implementations)
 
 
 @external

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -42,6 +42,7 @@ def factory(
     contract.add_base_pool(
         base_pool,
         fee_receiver,
+        0,
         [implementation_usd, implementation_rebase_usd] + [ZERO_ADDRESS] * 8,
         {"from": alice},
     )
@@ -130,6 +131,7 @@ def base_pool_btc(alice, fee_receiver, implementation_btc, factory, implementati
     factory.add_base_pool(
         pool,
         fee_receiver,
+        2,
         [implementation_btc, implementation_rebase_btc] + [ZERO_ADDRESS] * 8,
         {"from": alice},
     )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -53,11 +53,11 @@ def new_factory_setup(
         2, [implementation_plain] + [ZERO_ADDRESS] * 9, {"from": alice}
     )
     new_factory.add_base_pool(
-        base_pool, fee_receiver, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
+        base_pool, fee_receiver, 0, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
     )
     pool = Contract("0x7fC77b5c7614E1533320Ea6DDc2Eb61fa00A9714")
     new_factory.add_base_pool(
-        pool, fee_receiver, [implementation_btc] + [ZERO_ADDRESS] * 9, {"from": alice}
+        pool, fee_receiver, 2, [implementation_btc] + [ZERO_ADDRESS] * 9, {"from": alice}
     )
 
 
@@ -195,7 +195,7 @@ def test_get_coin_indices_reverts(factory, swap, base_lp_token, underlying_coins
 def test_add_base_pool(factory, alice, fee_receiver, implementation_usd):
     susd_pool = "0xA5407eAE9Ba41422680e2e00537571bcC53efBfD"
     factory.add_base_pool(
-        susd_pool, fee_receiver, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
+        susd_pool, fee_receiver, 0, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
     )
     assert factory.base_pool_count() == 3
     assert factory.base_pool_list(2) == susd_pool
@@ -205,7 +205,7 @@ def test_add_base_pool(factory, alice, fee_receiver, implementation_usd):
 def test_add_base_pool_already_exists(factory, base_pool, alice, fee_receiver, implementation_usd):
     with brownie.reverts("dev: pool exists"):
         factory.add_base_pool(
-            base_pool, fee_receiver, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
+            base_pool, fee_receiver, 0, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
         )
 
 
@@ -214,6 +214,7 @@ def test_add_base_pool_only_admin(factory, base_pool, bob, fee_receiver, impleme
         factory.add_base_pool(
             "0xA5407eAE9Ba41422680e2e00537571bcC53efBfD",
             fee_receiver,
+            0,
             [implementation_usd] + [ZERO_ADDRESS] * 9,
             {"from": bob},
         )
@@ -243,7 +244,7 @@ def test_add_existing_metapools(
     assert new_factory.pool_count() == 0
     # add existing USD pools to new factory
     new_factory.add_base_pool(
-        base_pool, fee_receiver, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
+        base_pool, fee_receiver, 0, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
     )
     new_factory.add_existing_metapools(
         ["0x5a6A4D54456819380173272A5E8E9B9904BdF41B", "0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c"]
@@ -267,7 +268,7 @@ def test_add_existing_metapools_duplicate_pool(
     new_factory, base_pool, implementation_usd, fee_receiver, alice
 ):
     new_factory.add_base_pool(
-        base_pool, fee_receiver, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
+        base_pool, fee_receiver, 0, [implementation_usd] + [ZERO_ADDRESS] * 9, {"from": alice}
     )
     new_factory.add_existing_metapools(
         ["0x5a6A4D54456819380173272A5E8E9B9904BdF41B"] + [ZERO_ADDRESS] * 9
@@ -285,7 +286,7 @@ def test_deploy_plain_pool(Plain2Basic, is_rebase, new_factory_setup, new_factor
     coins = [ERC20(decimals=7), ERC20(decimals=9), ZERO_ADDRESS, ZERO_ADDRESS]
 
     tx = new_factory.deploy_plain_pool(
-        "Test Plain", "TST", coins, 12345, 50000000, 0, {"from": bob}
+        "Test Plain", "TST", coins, 12345, 50000000, 0, 0, {"from": bob}
     )
     assert tx.return_value == tx.new_contracts[0]
     swap = Plain2Basic.at(tx.return_value)
@@ -306,7 +307,7 @@ def test_pool_count(new_factory, new_factory_setup, bob, base_pool):
     coins = [ERC20(decimals=7), ERC20(decimals=9), ZERO_ADDRESS, ZERO_ADDRESS]
 
     tx = new_factory.deploy_plain_pool(
-        "Test Plain", "TST", coins, 12345, 50000000, 0, {"from": bob}
+        "Test Plain", "TST", coins, 12345, 50000000, 0, 0, {"from": bob}
     )
     assert tx.return_value == tx.new_contracts[0]
     assert new_factory.pool_count() == 1
@@ -332,4 +333,4 @@ def test_deploy_plain_pool_revert(base_pool, new_factory, new_factory_setup, bob
     coins = [existing_coin, ERC20(decimals=9), ZERO_ADDRESS, ZERO_ADDRESS]
     # should revert because a metapool already exists for one of the coins
     with brownie.reverts("Invalid asset, deploy a metapool"):
-        new_factory.deploy_plain_pool("Test Plain", "TST", coins, 12345, 50000000, 0, {"from": bob})
+        new_factory.deploy_plain_pool("Test Plain", "TST", coins, 12345, 50000000, {"from": bob})

--- a/tests/test_owner_proxy.py
+++ b/tests/test_owner_proxy.py
@@ -116,6 +116,7 @@ def test_add_base_pool(owner_proxy, new_factory, base_pool_btc, implementation_b
         new_factory,
         base_pool_btc,
         ETH_ADDRESS,
+        2,
         [implementation_btc] + [ZERO_ADDRESS] * 9,
         {"from": alice},
     )
@@ -126,7 +127,7 @@ def test_add_base_pool(owner_proxy, new_factory, base_pool_btc, implementation_b
 def test_add_base_pool_guarded(owner_proxy, bob):
     with brownie.reverts("Access denied"):
         owner_proxy.add_base_pool(
-            ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS, [ZERO_ADDRESS] * 10, {"from": bob}
+            ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS, 0, [ZERO_ADDRESS] * 10, {"from": bob}
         )
 
 


### PR DESCRIPTION
### What I did
Categorize pools by asset type in the same way they are handled in the registry.  This is useful when sorting pools in the front-end.

As an asset type will inevitably be set incorrectly, I've also added a new "manager" role with limited admin permissions - presently, it can only modify the asset type.