### PR TITLE
LiquidityGauge implementation

### DIFF
--- a/contracts/LiquidityGauge.vy
+++ b/contracts/LiquidityGauge.vy
@@ -1,8 +1,9 @@
 # @version 0.2.15
 """
-@title Liquidity Gauge v3
+@title Liquidity Gauge
 @author Curve Finance
 @license MIT
+@notice Implementation contract for use with Curve Factory
 """
 
 from vyper.interfaces import ERC20

--- a/contracts/LiquidityGaugeV3.vy
+++ b/contracts/LiquidityGaugeV3.vy
@@ -372,33 +372,18 @@ def claimed_reward(_addr: address, _token: address) -> uint256:
 
 @view
 @external
-def claimable_reward(_addr: address, _token: address) -> uint256:
+def claimable_reward(_user: address, _reward_token: address) -> uint256:
     """
     @notice Get the number of claimable reward tokens for a user
-    @dev This call does not consider pending claimable amount in `reward_contract`.
-         Off-chain callers should instead use `claimable_rewards_write` as a
-         view method.
-    @param _addr Account to get reward amount for
-    @param _token Token to get reward amount for
+    @param _user Account to get reward amount for
+    @param _reward_token Token to get reward amount for
     @return uint256 Claimable reward token amount
     """
-    return shift(self.claim_data[_addr][_token], -128)
+    integral: uint256 = self._get_reward_integral(_reward_token)
+    integral_for: uint256 = self.reward_integral_for[_reward_token][_user]
+    new_claimable: uint256 = self.balanceOf[_user] * (integral - integral_for) / 10**18
 
-
-@external
-@nonreentrant('lock')
-def claimable_reward_write(_addr: address, _token: address) -> uint256:
-    """
-    @notice Get the number of claimable reward tokens for a user
-    @dev This function should be manually changed to "view" in the ABI
-         Calling it via a transaction will claim available reward tokens
-    @param _addr Account to get reward amount for
-    @param _token Token to get reward amount for
-    @return uint256 Claimable reward token amount
-    """
-    if self.reward_count != 0:
-        self._checkpoint_rewards(_addr, self.totalSupply, False, ZERO_ADDRESS)
-    return shift(self.claim_data[_addr][_token], -128)
+    return shift(self.claim_data[_user][_reward_token], -128) + new_claimable
 
 
 @external


### PR DESCRIPTION
### What I did
Tweak `LiquidityGaugeV3` from the dao repo to be suitable for use within the factory.

### How I did it
In the original version we allow onward staking of LP tokens to receive third party incentives. In the context of a permission-less gauge this presents too much complexity for the average DAO participant to evaluate the risk of a vote calling `set_rewards`. To mitigate, I've merged the logic of [`MultiRewards`](https://github.com/curvefi/multi-rewards/blob/master/contracts/MultiRewards.sol) into the gauge.  This way, rewards are added via `add_reward` and there is no chance of LP tokens being stolen or bricked due to maliciousness or human error.

### TODO
These are requirements for deployment, but they will be handled in separate PRs.

- [ ] Testing, particularly around the ported multirewards logic. Many of these tests can be adapted from existing ones within the dao and multirewards repos.
- [ ] Add logic and testing for boost delegation.