### PR TITLE
Boost Delegation

### DIFF
--- a/.github/workflows/boost_delegation.yaml
+++ b/.github/workflows/boost_delegation.yaml
@@ -20,7 +20,10 @@ jobs:
 
   unitary:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        stateful: [true, false]
     steps:
     - uses: actions/checkout@v2
 
@@ -49,4 +52,4 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/boost_delegation/
+      run: brownie test tests/boost_delegation/ --stateful ${{ matrix.stateful }}

--- a/.github/workflows/boost_delegation.yaml
+++ b/.github/workflows/boost_delegation.yaml
@@ -1,0 +1,52 @@
+name: boost delegation
+
+on:
+  pull_request:
+    paths:
+    - 'tests/boost_delegation/*.py'
+    - 'contracts/BoostDelegation.vy'
+  push:
+    paths:
+    - 'tests/boost_delegation/*.py'
+    - 'contracts/BoostDelegation.vy'
+
+env:
+  ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  WEB3_INFURA_PROJECT_ID: 4b7217c6901c42f2bd9e8509baa0699d
+  NODE_OPTIONS: --max_old_space_size=4096
+
+jobs:
+
+  unitary:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache Compiler Installations
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.solcx
+          ~/.vvm
+          ~/.brownie
+          /home/runner/work/curve-factory/build
+        key: compiler-cache
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+
+    - name: Install Ganache
+      run: npm install
+
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install Requirements
+      run: pip install -r requirements.txt
+
+    - name: Run Tests
+      run: brownie test tests/boost_delegation/

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -9,6 +9,21 @@
 from vyper.interfaces import ERC20
 
 
+event NewDelegation:
+    delegator: indexed(address)
+    gauge: indexed(address)
+    receiver: indexed(address)
+    pct: uint256
+    cancel_time: uint256
+    expire_time: uint256
+
+event CancelledDelegation:
+    delegator: indexed(address)
+    gauge: indexed(address)
+    receiver: indexed(address)
+    cancelled_by: address
+
+
 struct ReceivedBoost:
     length: uint256
     data: uint256[10]
@@ -176,6 +191,7 @@ def delegate_boost(
     self.delegated_to[_delegator][_gauge] = data + shift(convert(_receiver, uint256), -96)
     self.delegation_data[_receiver][_gauge].length = idx + 1
 
+    log NewDelegation(_delegator, _gauge, _receiver, _pct, _cancel_time, _expire_time)
     return True
 
 
@@ -201,6 +217,7 @@ def cancel_delegation(_delegator: address, _gauge: address) -> bool:
 
     self._delete_delegation_data(_delegator, _gauge, data)
 
+    log CancelledDelegation(_delegator, _gauge, receiver, msg.sender)
     return True
 
 

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -89,6 +89,8 @@ def delegate_boost(
     """
     assert msg.sender in [_delegator, self.operator[_delegator]], "Only owner or operator"
 
+    assert _delegator != _receiver, "Cannot delegate to self"
+    assert _pct >= 100, "Percent too low"
     assert _pct <= 10000, "Percent too high"
     assert _expire_time < 2**40, "Expiry time too high"
     assert _expire_time > block.timestamp, "Already expired"

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -123,7 +123,7 @@ def _delete_delegation_data(_delegator: address, _gauge: address, _delegation_da
     self.delegated_to[_delegator][_gauge] = 0
     self.delegation_count[_delegator] -= 1
 
-    receiver: address = convert(shift(_delegation_data, 96), address)
+    receiver: address = convert(shift(_delegation_data, -96), address)
     length: uint256 = self.delegation_data[receiver][_gauge].length
 
     # delete record for the receiver
@@ -134,6 +134,8 @@ def _delete_delegation_data(_delegator: address, _gauge: address, _delegation_da
         if self.delegation_data[receiver][_gauge].data[i] == _delegation_data:
             self.delegation_data[receiver][_gauge].data[i] = self.delegation_data[receiver][_gauge].data[length-1]
             self.delegation_data[receiver][_gauge].data[length-1] = 0
+
+    self.delegation_data[receiver][_gauge].length -= 1
 
 
 @external

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -169,16 +169,11 @@ def delegate_boost(
 
     # tightly pack the delegation data
     # [address][uint16 pct][uint40 cancel time][uint40 expire time]
-    data = (
-        shift(convert(_receiver, uint256), -96) +
-        shift(_pct, -80) +
-        shift(_cancel_time, -40) +
-        _expire_time
-    )
+    data = shift(_pct, -80) + shift(_cancel_time, -40) + _expire_time
     idx: uint256 = self.delegation_data[_receiver][_gauge].length
 
-    self.delegation_data[_receiver][_gauge].data[idx] = data
-    self.delegated_to[_delegator][_gauge] = data
+    self.delegation_data[_receiver][_gauge].data[idx] = data + shift(convert(_delegator, uint256), -96)
+    self.delegated_to[_delegator][_gauge] = data + shift(convert(_receiver, uint256), -96)
     self.delegation_data[_receiver][_gauge].length = idx + 1
 
     return True

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -248,13 +248,13 @@ def get_adjusted_vecrv_balance(_user: address, _gauge: address) -> uint256:
         if delegation_count == 1:
             data: uint256 = self.delegated_to[_user][ZERO_ADDRESS]
             if data % 2**40 > block.timestamp:
-                voting_balance = voting_balance * (10000 - shift(data, 80) % 2**16) / 10000
+                voting_balance = voting_balance * (10000 - shift(data, -80) % 2**16) / 10000
                 is_global = True
         # apply pool-specific delegation
         if not is_global:
             data: uint256 = self.delegated_to[_user][_gauge]
             if data % 2**40 > block.timestamp:
-                voting_balance = voting_balance * (10000 - shift(data, 80) % 2**16) / 10000
+                voting_balance = voting_balance * (10000 - shift(data, -80) % 2**16) / 10000
 
     # check for other vecrv delegated to `_user` and increase the voting balance
     for target in [_gauge, ZERO_ADDRESS]:
@@ -265,9 +265,11 @@ def get_adjusted_vecrv_balance(_user: address, _gauge: address) -> uint256:
                     break
                 data: uint256 = self.delegation_data[_user][target].data[i]
                 if data % 2**40 > block.timestamp:
-                    delegator: address = convert(shift(data, 96), address)
+                    delegator: address = convert(shift(data, -96), address)
                     delegator_balance: uint256 = ERC20(VOTING_ESCROW).balanceOf(delegator)
-                    voting_balance += delegator_balance * (shift(data, 80) % 2**16) / 10000
+                    voting_balance += delegator_balance * (shift(data, -80) % 2**16) / 10000
+        if target == ZERO_ADDRESS:
+            break
 
     return voting_balance
 

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -68,9 +68,9 @@ def get_delegated_to(_delegator: address, _gauge: address) -> (address, uint256,
     """
     data: uint256 = self.delegated_to[_delegator][_gauge]
     return (
-        convert(shift(data, 96), address),
-        shift(data, 80) % 2**16,
-        shift(data, 40) % 2**40,
+        convert(shift(data, -96), address),
+        shift(data, -80) % 2**16,
+        shift(data, -40) % 2**40,
         data % 2**40
     )
 

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -94,9 +94,9 @@ def get_delegation_data(
     """
     data: uint256 = self.delegation_data[_receiver][_gauge].data[_idx]
     return (
-        convert(shift(data, 96), address),
-        shift(data, 80) % 2**16,
-        shift(data, 40) % 2**40,
+        convert(shift(data, -96), address),
+        shift(data, -80) % 2**16,
+        shift(data, -40) % 2**40,
         data % 2**40
     )
 

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -125,13 +125,14 @@ def _delete_delegation_data(_delegator: address, _gauge: address, _delegation_da
 
     receiver: address = convert(shift(_delegation_data, -96), address)
     length: uint256 = self.delegation_data[receiver][_gauge].length
+    delegation_data: uint256 = shift(convert(receiver, uint256), -96) + (_delegation_data % 2 ** 96)
 
     # delete record for the receiver
     for i in range(10):
         if i == length - 1:
             self.delegation_data[receiver][_gauge].data[i] = 0
             break
-        if self.delegation_data[receiver][_gauge].data[i] == _delegation_data:
+        if self.delegation_data[receiver][_gauge].data[i] == delegation_data:
             self.delegation_data[receiver][_gauge].data[i] = self.delegation_data[receiver][_gauge].data[length-1]
             self.delegation_data[receiver][_gauge].data[length-1] = 0
 
@@ -269,6 +270,7 @@ def get_adjusted_vecrv_balance(_user: address, _gauge: address) -> uint256:
                     delegator_balance: uint256 = ERC20(VOTING_ESCROW).balanceOf(delegator)
                     voting_balance += delegator_balance * (shift(data, -80) % 2**16) / 10000
         if target == ZERO_ADDRESS:
+            # prevents double accounting global delegations
             break
 
     return voting_balance

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -292,7 +292,7 @@ def update_delegation_records(_user: address, _gauge: address) -> bool:
         data: uint256 = self.delegation_data[_user][_gauge].data[idx]
         if data % 2**40 <= block.timestamp:
             # delete record for the delegator
-            delegator: address = convert(shift(data, 96), address)
+            delegator: address = convert(shift(data, -96), address)
             self.delegated_to[delegator][_gauge] = 0
             self.delegation_count[delegator] -= 1
 
@@ -301,7 +301,7 @@ def update_delegation_records(_user: address, _gauge: address) -> bool:
                 self.delegation_data[_user][_gauge].data[idx] = 0
             else:
                 self.delegation_data[_user][_gauge].data[idx] = self.delegation_data[_user][_gauge].data[adjusted_length]
-            adjusted_length -= 1
+                adjusted_length -= 1
 
     return True
 

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -1,0 +1,219 @@
+# @version 0.2.15
+"""
+@title Boost Delegation
+@author Curve Finance
+@license MIT
+@notice Allows delegation of veCRV boost within factory gauges
+"""
+
+from vyper.interfaces import ERC20
+
+
+struct ReceivedBoost:
+    length: uint256
+    data: uint256[10]
+
+
+# user -> data on global boosts delegated to user
+# delegation data is tightly packed as [address][uint16 pct][uint40 cancel time][uint40 expire time]
+delegation_count: HashMap[address, uint256]
+
+# user -> pool -> data on per-pool boosts delegated to user
+delegation_data: HashMap[address, HashMap[address, ReceivedBoost]]
+
+# user -> pool -> address that user has delegated boost to for this pool
+delegated_to: public(HashMap[address, HashMap[address, uint256]])
+
+operator: HashMap[address, address]
+
+VOTING_ESCROW: constant(address) = 0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2
+
+
+@external
+def set_operator(_operator: address) -> bool:
+    """
+    @notice Set the authorized operator for an address
+    @dev An operator can delegate boost, including creating delegations that
+         cannot be cancelled. This permission should only be given to trusted
+         3rd parties and smart contracts where the contract behavior is known
+         to be not malicious.
+    @param _operator Approved operator address. Set to `ZERO_ADDRESS` to revoke
+                     the currently active approval.
+    @return bool success
+    """
+    self.operator[msg.sender] = _operator
+    return True
+
+
+@internal
+def _delete_delegation_data(_delegator: address, _gauge: address, _delegation_data: uint256):
+    # delete record for the delegator
+    self.delegated_to[_delegator][_gauge] = 0
+    self.delegation_count[_delegator] -= 1
+
+    receiver: address = convert(shift(_delegation_data, 96), address)
+    length: uint256 = self.delegation_data[receiver][_gauge].length
+
+    # delete record for the receiver
+    for i in range(10):
+        if i == length - 1:
+            self.delegation_data[receiver][_gauge].data[i] = 0
+            break
+        if self.delegation_data[receiver][_gauge].data[i] == _delegation_data:
+            self.delegation_data[receiver][_gauge].data[i] = self.delegation_data[receiver][_gauge].data[length-1]
+            self.delegation_data[receiver][_gauge].data[length-1] = 0
+
+
+@external
+def delegate_boost(
+    _delegator: address,
+    _gauge: address,
+    _receiver: address,
+    _pct: uint256,
+    _cancel_time: uint256,
+    _expire_time: uint256
+) -> bool:
+    """
+    @notice Delegate per-gauge or global boost to another account
+    @param _delegator Address of the user delegating boost. The caller must be the
+                      delegator or the approved operator of the delegator.
+    @param _gauge Address of the gauge to delegate for. Set as ZERO_ADDRESS for
+                  global delegation. Global delegation is not possible if there is
+                  also one or more active per-gauge delegations.
+    @param _receiver Address to delegate boost to.
+    @param _pct Percentage of boost to delegate. 100% is expressed as 10000.
+    @param _cancel_time Delegation cannot be cancelled before this time.
+    @param _expire_time Delegation automatically expires at this time.
+    @return bool success
+    """
+    assert msg.sender in [_delegator, self.operator[_delegator]], "Only owner or operator"
+
+    assert _pct <= 10000, "Percent too high"
+    assert _expire_time < 2**40, "Expiry time too high"
+    assert _expire_time > block.timestamp, "Already expired"
+    assert _cancel_time <= _expire_time, "Cancel time after expiry time"
+
+    # check for an existing, expired delegation
+    data: uint256 = self.delegated_to[_delegator][_gauge]
+    if data != 0:
+        assert data % 2**40 <= block.timestamp, "Existing delegation has not expired"
+        self._delete_delegation_data(_delegator, _gauge, data)
+
+    if _gauge == ZERO_ADDRESS:
+        assert self.delegation_count[_delegator] == 0, "Cannot delegate globally while per-gauge is active"
+    else:
+        assert self.delegated_to[_delegator][ZERO_ADDRESS] == 0, "Cannot delegate per-gauge while global is active"
+
+    # tightly pack the delegation data
+    # [address][uint16 pct][uint40 cancel time][uint40 expire time]
+    data = (
+        shift(convert(_receiver, uint256), -96) +
+        shift(_pct, -80) +
+        shift(_cancel_time, -40) +
+        _expire_time
+    )
+    idx: uint256 = self.delegation_data[_receiver][_gauge].length
+
+    self.delegation_data[_receiver][_gauge].data[idx] = data
+    self.delegated_to[_delegator][_gauge] = data
+    self.delegation_data[_receiver][_gauge].length = idx + 1
+
+    return True
+
+
+@external
+def cancel_delegation(_delegator: address, _gauge: address) -> bool:
+    """
+    @notice Cancel an existing boost delegation
+    @param _delegator Address of the user delegating boost. The caller must be the
+                      delegator or the approved operator of the delegator.
+    @param _gauge Address of the gauge to cancel delegattion for. Set as ZERO_ADDRESS
+                  for global delegation.
+    @return bool success
+    """
+    assert msg.sender in [_delegator, self.operator[_delegator]], "Only owner or operator"
+
+    data: uint256 = self.delegated_to[_delegator][_gauge]
+    assert data != 0, "No delegation for this pool"
+    assert shift(data, 40) % 2**40 <= block.timestamp, "Not yet cancellable"
+    self._delete_delegation_data(_delegator, _gauge, data)
+
+    return True
+
+
+@view
+@external
+def get_adjusted_vecrv_balance(_user: address, _gauge: address) -> uint256:
+    """
+    @notice Get the adjusted veCRV balance of an account after delegation
+    @param _user Address to query a veCRV balance for
+    @param _gauge Gauge address
+    @return Adjusted veCRV balance after delegation
+    """
+    # query the initial vecrv balance for `_user`
+    voting_balance: uint256 = ERC20(VOTING_ESCROW).balanceOf(_user)
+
+    # check if the user has delegated any vecrv and reduce the voting balance
+    delegation_count: uint256 = self.delegation_count[_user]
+    if delegation_count != 0:
+        is_global: bool = False
+        # apply global delegation
+        if delegation_count == 1:
+            data: uint256 = self.delegated_to[_user][ZERO_ADDRESS]
+            if data % 2**40 > block.timestamp:
+                voting_balance = voting_balance * (10000 - shift(data, 80) % 2**16) / 10000
+                is_global = True
+        # apply pool-specific delegation
+        if not is_global:
+            data: uint256 = self.delegated_to[_user][_gauge]
+            if data % 2**40 > block.timestamp:
+                voting_balance = voting_balance * (10000 - shift(data, 80) % 2**16) / 10000
+
+    # check for other vecrv delegated to `_user` and increase the voting balance
+    for target in [_gauge, ZERO_ADDRESS]:
+        length: uint256 = self.delegation_data[_user][target].length
+        if length > 0:
+            for i in range(10):
+                if i == length:
+                    break
+                data: uint256 = self.delegation_data[_user][target].data[i]
+                if data % 2**40 > block.timestamp:
+                    delegator: address = convert(shift(data, 96), address)
+                    delegator_balance: uint256 = ERC20(VOTING_ESCROW).balanceOf(delegator)
+                    voting_balance += delegator_balance * (shift(data, 80) % 2**16) / 10000
+
+    return voting_balance
+
+
+@external
+def update_delegation_records(_user: address, _gauge: address) -> bool:
+    """
+    @notice Remove data about any expired delegations for a user.
+    @dev Reduces gas costs when calling `get_adjusted_vecrv_balance` on
+         an address with expired delegations.
+    @param _user Address to update records for.
+    @param _gauge Gauge address. Use `ZERO_ADDRESS` for global delegations.
+    """
+    length: uint256 = self.delegation_data[_user][_gauge].length - 1
+    adjusted_length: uint256 = length
+
+    # iterate in reverse over `delegation_data` and remove expired records
+    for i in range(10):
+        if i > length:
+            break
+        idx: uint256 = length - i
+        data: uint256 = self.delegation_data[_user][_gauge].data[idx]
+        if data % 2**40 <= block.timestamp:
+            # delete record for the delegator
+            delegator: address = convert(shift(data, 96), address)
+            self.delegated_to[delegator][_gauge] = 0
+            self.delegation_count[delegator] -= 1
+
+            # delete record for the receiver
+            if idx == adjusted_length:
+                self.delegation_data[_user][_gauge].data[idx] = 0
+            else:
+                self.delegation_data[_user][_gauge].data[idx] = self.delegation_data[_user][_gauge].data[adjusted_length]
+            adjusted_length -= 1
+
+    return True

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -184,11 +184,11 @@ def delegate_boost(
 
     # tightly pack the delegation data
     # [address][uint16 pct][uint40 cancel time][uint40 expire time]
-    data = shift(_pct, -80) + shift(_cancel_time, -40) + _expire_time
+    data = shift(_pct, 80) + shift(_cancel_time, 40) + _expire_time
     idx: uint256 = self.delegation_data[_receiver][_gauge].length
 
-    self.delegation_data[_receiver][_gauge].data[idx] = data + shift(convert(_delegator, uint256), -96)
-    self.delegated_to[_delegator][_gauge] = data + shift(convert(_receiver, uint256), -96)
+    self.delegation_data[_receiver][_gauge].data[idx] = data + shift(convert(_delegator, uint256), 96)
+    self.delegated_to[_delegator][_gauge] = data + shift(convert(_receiver, uint256), 96)
     self.delegation_data[_receiver][_gauge].length = idx + 1
     self.delegation_count[_delegator] += 1
 

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -27,6 +27,7 @@ delegated_to: public(HashMap[address, HashMap[address, uint256]])
 operator: HashMap[address, address]
 
 VOTING_ESCROW: constant(address) = 0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2
+MIN_VECRV: constant(uint256) = 2500 * 10**18
 
 
 @external
@@ -92,6 +93,9 @@ def delegate_boost(
     assert _expire_time < 2**40, "Expiry time too high"
     assert _expire_time > block.timestamp, "Already expired"
     assert _cancel_time <= _expire_time, "Cancel time after expiry time"
+
+    # check for minimum veCRV balance, used to prevent 0 veCRV delegation spam
+    assert ERC20(VOTING_ESCROW).balanceOf(_delegator) >= MIN_VECRV, "Insufficient veCRV to delegate"
 
     # check for an existing, expired delegation
     data: uint256 = self.delegated_to[_delegator][_gauge]

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -190,6 +190,7 @@ def delegate_boost(
     self.delegation_data[_receiver][_gauge].data[idx] = data + shift(convert(_delegator, uint256), -96)
     self.delegated_to[_delegator][_gauge] = data + shift(convert(_receiver, uint256), -96)
     self.delegation_data[_receiver][_gauge].length = idx + 1
+    self.delegation_count[_delegator] += 1
 
     log NewDelegation(_delegator, _gauge, _receiver, _pct, _cancel_time, _expire_time)
     return True

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -213,10 +213,10 @@ def cancel_delegation(_delegator: address, _gauge: address) -> bool:
     data: uint256 = self.delegated_to[_delegator][_gauge]
     assert data != 0, "No delegation for this pool"
 
-    receiver: address = convert(shift(data, 96), address)
+    receiver: address = convert(shift(data, -96), address)
     if msg.sender not in [receiver, self.operator_of[receiver]]:
-        assert msg.sender in [receiver, self.operator_of[receiver]], "Only owner or operator"
-        assert shift(data, 40) % 2**40 <= block.timestamp, "Not yet cancellable"
+        assert msg.sender in [_delegator, self.operator_of[_delegator]], "Only delegator or delegator's operator"
+        assert shift(data, -40) % 2**40 <= block.timestamp, "Not yet cancellable"
 
     self._delete_delegation_data(_delegator, _gauge, data)
 

--- a/contracts/BoostDelegation.vy
+++ b/contracts/BoostDelegation.vy
@@ -125,16 +125,18 @@ def _delete_delegation_data(_delegator: address, _gauge: address, _delegation_da
 
     receiver: address = convert(shift(_delegation_data, -96), address)
     length: uint256 = self.delegation_data[receiver][_gauge].length
-    delegation_data: uint256 = shift(convert(receiver, uint256), -96) + (_delegation_data % 2 ** 96)
+    # this is the correct data we have to match
+    data: uint256 = shift(convert(_delegator, uint256), 96) + (_delegation_data % 2 ** 96)
 
     # delete record for the receiver
     for i in range(10):
         if i == length - 1:
             self.delegation_data[receiver][_gauge].data[i] = 0
             break
-        if self.delegation_data[receiver][_gauge].data[i] == delegation_data:
+        if self.delegation_data[receiver][_gauge].data[i] == data:
             self.delegation_data[receiver][_gauge].data[i] = self.delegation_data[receiver][_gauge].data[length-1]
             self.delegation_data[receiver][_gauge].data[length-1] = 0
+            break
 
     self.delegation_data[receiver][_gauge].length -= 1
 

--- a/contracts/LiquidityGauge.vy
+++ b/contracts/LiquidityGauge.vy
@@ -39,6 +39,9 @@ interface ERC20Extended:
 interface Factory:
     def admin() -> address: view
 
+interface Delegator:
+    def get_adjusted_vecrv_balance(_user: address, _gauge: address) -> uint256: view
+
 
 event Deposit:
     provider: indexed(address)
@@ -90,7 +93,7 @@ MINTER: constant(address) = 0xd061D61a4d941c39E5453435B6345Dc261C2fcE0
 CRV: constant(address) = 0xD533a949740bb3306d119CC777fa900bA034cd52
 VOTING_ESCROW: constant(address) = 0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2
 GAUGE_CONTROLLER: constant(address) = 0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB
-
+BOOST_DELEGATION: constant(address) = 0x0000000000000000000000000000000000000000  # TODO set this
 
 lp_token: public(address)
 future_epoch_time: public(uint256)
@@ -194,7 +197,7 @@ def _update_liquidity_limit(addr: address, l: uint256, L: uint256):
     @param L Total amount of liquidity (LP tokens)
     """
     # To be called after totalSupply is updated
-    voting_balance: uint256 = ERC20(VOTING_ESCROW).balanceOf(addr)
+    voting_balance: uint256 = Delegator(BOOST_DELEGATION).get_adjusted_vecrv_balance(addr, self)
     voting_total: uint256 = ERC20(VOTING_ESCROW).totalSupply()
 
     lim: uint256 = l * TOKENLESS_PRODUCTION / 100

--- a/tests/boost_delegation/test_cancel_delegation.py
+++ b/tests/boost_delegation/test_cancel_delegation.py
@@ -1,0 +1,70 @@
+import itertools as it
+
+import brownie
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+DAY = 86400
+
+
+@pytest.fixture(params=[ZERO_ADDRESS, ETH_ADDRESS], ids=["GlobalDelegation", "GaugeDelegation"])
+def delegated_gauge(request):
+    return request.param
+
+
+@pytest.fixture(autouse=True)
+def setup(alice, chain, bob, charlie, dave, boost_delegation, lock_crv, delegated_gauge):
+    boost_delegation.delegate_boost(
+        alice,
+        delegated_gauge,
+        bob,
+        10_000,
+        chain.time() + DAY * 30,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+    for user, operator in zip([alice, bob], [charlie, dave]):
+        boost_delegation.set_operator(operator, {"from": user})
+
+
+@pytest.mark.parametrize("is_operator", [0, 1])
+def test_delegator_or_operator_cancels(
+    alice, bob, chain, charlie, boost_delegation, delegated_gauge, is_operator
+):
+    caller = charlie if is_operator else alice
+    chain.sleep(DAY * 30)  # must wait after the 30 days
+    tx = boost_delegation.cancel_delegation(alice, delegated_gauge, {"from": caller})
+
+    assert boost_delegation.get_delegated_to(alice, delegated_gauge) == [ZERO_ADDRESS, 0, 0, 0]
+    assert boost_delegation.get_delegation_data(bob, delegated_gauge, 0) == [ZERO_ADDRESS, 0, 0, 0]
+    assert "CancelledDelegation" in tx.events
+    assert tx.events["CancelledDelegation"].values() == [alice, delegated_gauge, bob, caller]
+
+
+@pytest.mark.parametrize("is_operator,timedelta", it.product([0, 1], repeat=2))
+def test_delegatee_or_operator_cancels_at_anytime(
+    alice, chain, bob, dave, boost_delegation, delegated_gauge, is_operator, timedelta
+):
+    caller = dave if is_operator else bob
+    chain.sleep(DAY * int(29.5 + timedelta))  # before or after cancellable time
+    tx = boost_delegation.cancel_delegation(alice, delegated_gauge, {"from": caller})
+
+    assert boost_delegation.get_delegated_to(alice, delegated_gauge) == [ZERO_ADDRESS, 0, 0, 0]
+    assert boost_delegation.get_delegation_data(bob, delegated_gauge, 0) == [ZERO_ADDRESS, 0, 0, 0]
+    assert "CancelledDelegation" in tx.events
+    assert tx.events["CancelledDelegation"].values() == [alice, delegated_gauge, bob, caller]
+
+
+@pytest.mark.parametrize("is_operator", [0, 1])
+def test_delegator_or_operator_cancel_reverts_before_allowed_time(
+    alice, chain, charlie, boost_delegation, delegated_gauge, is_operator
+):
+    caller = charlie if is_operator else alice
+    chain.sleep(DAY * 29)
+    with brownie.reverts("Not yet cancellable"):
+        boost_delegation.cancel_delegation(alice, delegated_gauge, {"from": caller})
+
+
+def test_third_party_cannot_cancel(alice, erin, boost_delegation, delegated_gauge):
+    with brownie.reverts("Only delegator or delegator's operator"):
+        boost_delegation.cancel_delegation(alice, delegated_gauge, {"from": erin})

--- a/tests/boost_delegation/test_delegate_boost.py
+++ b/tests/boost_delegation/test_delegate_boost.py
@@ -1,0 +1,213 @@
+import brownie
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+pytestmark = pytest.mark.usefixtures("lock_crv")
+
+DAY = 86400
+
+
+@pytest.fixture
+def alice_vecrv_balance(alice, voting_escrow, lock_crv):
+    return voting_escrow.balanceOf(alice)
+
+
+@pytest.fixture
+def lock_bob(alice, bob, crv, voting_escrow, chain):
+    lock_amt = crv.balanceOf(alice) // 2
+    crv.transfer(bob, lock_amt, {"from": alice})
+    crv.approve(voting_escrow, lock_amt, {"from": bob})
+    voting_escrow.create_lock(lock_amt, chain.time() + DAY * 365 * 4, {"from": bob})
+
+
+@pytest.fixture(autouse=True)
+def delegate_bob(alice, bob, boost_delegation, chain, alice_vecrv_balance):
+    boost_delegation.delegate_boost(
+        alice,
+        ETH_ADDRESS,
+        bob,
+        10000,
+        chain.time() + DAY * 31,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+
+
+def test_delegation_count(alice, boost_delegation):
+    assert boost_delegation.delegation_count(alice) == 1
+
+
+def test_operator_delegates(alice, bob, boost_delegation, chain, lock_bob):
+    boost_delegation.set_operator(alice, {"from": bob})
+
+    boost_delegation.delegate_boost(
+        bob,
+        ETH_ADDRESS,
+        alice,
+        10000,
+        chain.time() + DAY * 31,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+
+    assert boost_delegation.delegation_count(bob) == 1
+
+
+def test_delegation_data(alice, history, bob, boost_delegation):
+    data = boost_delegation.get_delegation_data(bob, ETH_ADDRESS, 0)
+    delegation_tx_time = history[-1].timestamp
+    expected = (alice, 10_000, delegation_tx_time + DAY * 31, delegation_tx_time + DAY * 365)
+    assert data[:2] == expected[:2]
+    assert abs(data[2] - expected[2]) <= 1
+    assert abs(data[3] - expected[3]) <= 1
+
+
+def test_delegation_to_data(alice, history, bob, boost_delegation):
+    data = boost_delegation.get_delegated_to(alice, ETH_ADDRESS)
+    delegation_tx_time = history[-1].timestamp
+    expected = (bob, 10_000, delegation_tx_time + DAY * 31, delegation_tx_time + DAY * 365)
+    assert data[:2] == expected[:2]
+    assert abs(data[2] - expected[2]) <= 1
+    assert abs(data[3] - expected[3]) <= 1
+
+
+def test_event_emitted(alice, bob, history):
+    tx = history[-1]
+    expected = dict(
+        delegator=alice.address,
+        gauge=ETH_ADDRESS,
+        receiver=bob.address,
+        pct=10_000,
+        cancel_time=tx.timestamp + DAY * 31,
+        expire_time=tx.timestamp + DAY * 365,
+    )
+
+    assert "NewDelegation" in tx.events
+    assert dict(tx.events["NewDelegation"]) == expected
+
+
+def test_killed_guard(alice, bob, boost_delegation, chain, lock_bob):
+    boost_delegation.set_killed(True, {"from": alice})
+
+    with brownie.reverts("Is killed"):
+        boost_delegation.delegate_boost(
+            bob, ETH_ADDRESS, alice, 10_000, chain.time() + 1, chain.time() + DAY, {"from": bob}
+        )
+
+
+def test_call_guard_operator(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Only owner or operator"):
+        boost_delegation.delegate_boost(
+            bob, ETH_ADDRESS, alice, 10_000, chain.time() + 1, chain.time() + DAY, {"from": alice}
+        )
+
+
+def test_call_guard_self(bob, boost_delegation, chain):
+    with brownie.reverts("Cannot delegate to self"):
+        boost_delegation.delegate_boost(
+            bob, ETH_ADDRESS, bob, 10_000, chain.time() + 1, chain.time() + DAY, {"from": bob}
+        )
+
+
+def test_pct_minimum_guard(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Percent too low"):
+        boost_delegation.delegate_boost(
+            bob, ETH_ADDRESS, alice, 99, chain.time() + 1, chain.time() + DAY, {"from": bob}
+        )
+
+
+def test_pct_maximum_guard(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Percent too high"):
+        boost_delegation.delegate_boost(
+            bob, ETH_ADDRESS, alice, 10_001, chain.time() + 1, chain.time() + DAY, {"from": bob}
+        )
+
+
+def test_expire_time_max_guard(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Expiry time too high"):
+        boost_delegation.delegate_boost(
+            bob, ETH_ADDRESS, alice, 10_000, chain.time() + 1, 2 ** 40 + 1, {"from": bob}
+        )
+
+
+def test_expire_time_min_guard(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Already expired"):
+        boost_delegation.delegate_boost(
+            bob, ETH_ADDRESS, alice, 10_000, chain.time() + 1, chain.time() - 1, {"from": bob}
+        )
+
+
+def test_cancel_time_guard(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Cancel time after expiry time"):
+        boost_delegation.delegate_boost(
+            bob,
+            ETH_ADDRESS,
+            alice,
+            10_000,
+            chain.time() + DAY * 31,
+            chain.time() + DAY * 30,
+            {"from": bob},
+        )
+
+
+def test_insufficient_vecrv_balance(bob, charlie, boost_delegation, chain):
+    with brownie.reverts("Insufficient veCRV to delegate"):
+        boost_delegation.delegate_boost(
+            charlie,
+            ETH_ADDRESS,
+            bob,
+            10_000,
+            chain.time() + DAY * 31,
+            chain.time() + DAY * 365,
+            {"from": charlie},
+        )
+
+
+def test_existing_delegation_non_expired(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Existing delegation has not expired"):
+        boost_delegation.delegate_boost(
+            alice,
+            ETH_ADDRESS,
+            bob,
+            10_000,
+            chain.time() + DAY * 31,
+            chain.time() + DAY * 365,
+            {"from": alice},
+        )
+
+
+def test_delegating_global_while_per_pool_active_guard(alice, bob, boost_delegation, chain):
+    with brownie.reverts("Cannot delegate globally while per-gauge is active"):
+        boost_delegation.delegate_boost(
+            alice,
+            ZERO_ADDRESS,
+            bob,
+            10_000,
+            chain.time() + DAY * 31,
+            chain.time() + DAY * 365,
+            {"from": alice},
+        )
+
+
+def test_delegating_per_gauge_while_global_active_guard(
+    alice, bob, boost_delegation, chain, lock_bob
+):
+    boost_delegation.delegate_boost(
+        bob,
+        ZERO_ADDRESS,
+        alice,
+        10_000,
+        chain.time() + DAY * 31,
+        chain.time() + DAY * 365,
+        {"from": bob},
+    )
+    with brownie.reverts("Cannot delegate per-gauge while global is active"):
+        boost_delegation.delegate_boost(
+            bob,
+            ETH_ADDRESS,
+            alice,
+            10_000,
+            chain.time() + DAY * 31,
+            chain.time() + DAY * 365,
+            {"from": bob},
+        )

--- a/tests/boost_delegation/test_delegate_boost_delete_prev_data.py
+++ b/tests/boost_delegation/test_delegate_boost_delete_prev_data.py
@@ -1,0 +1,109 @@
+import brownie
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+pytestmark = pytest.mark.usefixtures("lock_crv")
+
+DAY = 86400
+
+
+@pytest.mark.parametrize("gauge_to", [ZERO_ADDRESS, ETH_ADDRESS])
+def test_expired_delegation_is_implicitly_deleted_delegatee(
+    alice, bob, boost_delegation, chain, gauge_to
+):
+    boost_delegation.delegate_boost(
+        alice,
+        gauge_to,
+        bob,
+        10000,
+        chain.time() + DAY * 31,  # cancel time
+        chain.time() + DAY * 365,  # expire time
+        {"from": alice},
+    )
+
+    chain.sleep(DAY * 366)
+
+    tx = boost_delegation.delegate_boost(
+        alice,
+        gauge_to,
+        bob,
+        10000,
+        chain.time() + DAY * 31,  # cancel time
+        chain.time() + DAY * 365,  # expire time
+        {"from": alice},
+    )
+
+    data = boost_delegation.get_delegation_data(bob, gauge_to, 0)
+    delegation_tx_time = tx.timestamp
+    expected = (alice, 10_000, delegation_tx_time + DAY * 31, delegation_tx_time + DAY * 365)
+
+    assert data[:2] == expected[:2]
+    assert abs(data[2] - expected[2]) <= 1
+    assert abs(data[3] - expected[3]) <= 1
+    assert boost_delegation.delegation_count(alice) == 1
+
+
+@pytest.mark.parametrize("gauge_to", [ZERO_ADDRESS, ETH_ADDRESS])
+def test_expired_delegation_is_implicitly_deleted_delegator(
+    alice, bob, boost_delegation, chain, gauge_to
+):
+    boost_delegation.delegate_boost(
+        alice,
+        gauge_to,
+        bob,
+        10000,
+        chain.time() + DAY * 31,  # cancel time
+        chain.time() + DAY * 365,  # expire time
+        {"from": alice},
+    )
+
+    chain.sleep(DAY * 366)
+
+    tx = boost_delegation.delegate_boost(
+        alice,
+        gauge_to,
+        bob,
+        10000,
+        chain.time() + DAY * 31,  # cancel time
+        chain.time() + DAY * 365,  # expire time
+        {"from": alice},
+    )
+
+    data = boost_delegation.get_delegated_to(alice, gauge_to)
+    delegation_tx_time = tx.timestamp
+    expected = (bob, 10_000, delegation_tx_time + DAY * 31, delegation_tx_time + DAY * 365)
+    assert data[:2] == expected[:2]
+    assert abs(data[2] - expected[2]) <= 1
+    assert abs(data[3] - expected[3]) <= 1
+
+
+@pytest.mark.parametrize(
+    "gauge_a,gauge_b", [(ZERO_ADDRESS, ETH_ADDRESS), (ETH_ADDRESS, ZERO_ADDRESS)]
+)
+def test_going_from_global_to_per_pool_requires_state_update(
+    alice, bob, boost_delegation, chain, gauge_a, gauge_b
+):
+    a_msg, b_msg = ("globally", "per-gauge") if gauge_a == ETH_ADDRESS else ("per-gauge", "global")
+
+    boost_delegation.delegate_boost(
+        alice,
+        gauge_a,
+        bob,
+        10000,
+        chain.time() + DAY * 31,  # cancel time
+        chain.time() + DAY * 365,  # expire time
+        {"from": alice},
+    )
+
+    chain.sleep(DAY * 366)
+
+    with brownie.reverts(f"Cannot delegate {a_msg} while {b_msg} is active"):
+        boost_delegation.delegate_boost(
+            alice,
+            gauge_b,
+            bob,
+            10000,
+            chain.time() + DAY * 31,  # cancel time
+            chain.time() + DAY * 365,  # expire time
+            {"from": alice},
+        )

--- a/tests/boost_delegation/test_get_adjusted_vecrv_balance.py
+++ b/tests/boost_delegation/test_get_adjusted_vecrv_balance.py
@@ -1,0 +1,63 @@
+import itertools as it
+import math
+
+import brownie
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+DAY = 86400
+
+
+@pytest.mark.parametrize(
+    "delegated_gauge,percentage", it.product([ZERO_ADDRESS, ETH_ADDRESS], range(1000, 10_000, 1000))
+)
+def test_delegation_adjustment(
+    alice, bob, boost_delegation, chain, voting_escrow, lock_crv, delegated_gauge, percentage
+):
+    boost_delegation.delegate_boost(
+        alice,
+        delegated_gauge,
+        bob,
+        percentage,
+        chain.time() + DAY * 30,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+
+    alice_vecrv_balance = voting_escrow.balanceOf(alice)
+    ratio = percentage / 10_000
+
+    alice_adjusted_vecrv_bal = boost_delegation.get_adjusted_vecrv_balance(alice, delegated_gauge)
+    bob_adjusted_vecrv_bal = boost_delegation.get_adjusted_vecrv_balance(bob, delegated_gauge)
+
+    assert math.isclose(alice_adjusted_vecrv_bal, (1 - ratio) * alice_vecrv_balance, rel_tol=0.0001)
+    assert math.isclose(bob_adjusted_vecrv_bal, ratio * alice_vecrv_balance, rel_tol=0.0001)
+
+
+@pytest.mark.parametrize("delegated_gauge", [ZERO_ADDRESS, ETH_ADDRESS])
+def test_delegation_adjustment_after_expiry(
+    alice, bob, boost_delegation, chain, voting_escrow, lock_crv, delegated_gauge
+):
+    boost_delegation.delegate_boost(
+        alice,
+        delegated_gauge,
+        bob,
+        10_000,
+        chain.time() + DAY * 30,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+
+    chain.mine(timedelta=DAY * 365 + 1)
+
+    alice_vecrv_balance = voting_escrow.balanceOf(alice)
+
+    brownie.multicall.deploy({"from": alice})
+
+    with brownie.multicall(block_identifier=chain.height):
+        alice_adj_vecrv_bal = boost_delegation.get_adjusted_vecrv_balance(alice, delegated_gauge)
+        bob_adjusted_vecrv_bal = boost_delegation.get_adjusted_vecrv_balance(bob, delegated_gauge)
+        alice_vecrv_balance = voting_escrow.balanceOf(alice)
+
+    assert alice_adj_vecrv_bal == alice_vecrv_balance
+    assert bob_adjusted_vecrv_bal == 0

--- a/tests/boost_delegation/test_kill_switch.py
+++ b/tests/boost_delegation/test_kill_switch.py
@@ -1,0 +1,30 @@
+import brownie
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+DAY = 86400
+
+
+@pytest.mark.parametrize("delegated_gauge", [ZERO_ADDRESS, ETH_ADDRESS])
+def test_delegation_adjustment(
+    alice, bob, boost_delegation, chain, voting_escrow, lock_crv, delegated_gauge
+):
+    boost_delegation.delegate_boost(
+        alice,
+        delegated_gauge,
+        bob,
+        10_000,
+        chain.time() + DAY * 30,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+
+    boost_delegation.set_killed(True, {"from": alice})
+
+    brownie.multicall.deploy({"from": alice})
+
+    with brownie.multicall(block_identifier=chain.height):
+        alice_vecrv_balance = voting_escrow.balanceOf(alice)
+        alice_adj_vecrv_bal = boost_delegation.get_adjusted_vecrv_balance(alice, delegated_gauge)
+        assert alice_adj_vecrv_bal == alice_vecrv_balance
+        assert boost_delegation.get_adjusted_vecrv_balance(bob, delegated_gauge) == 0

--- a/tests/boost_delegation/test_multiple_delegations.py
+++ b/tests/boost_delegation/test_multiple_delegations.py
@@ -1,0 +1,73 @@
+import math
+
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+DAY = 86400
+
+
+@pytest.fixture(autouse=True)
+def fund_vecrv_accounts(alice, bob, charlie, chain, dave, crv, voting_escrow, lock_crv):
+    alice_balance = crv.balanceOf(alice)
+    for receiver in [bob, charlie]:
+        crv.transfer(receiver, alice_balance // 2, {"from": alice})
+        crv.approve(voting_escrow, 2 ** 256 - 1, {"from": receiver})
+        voting_escrow.create_lock(
+            alice_balance // 2, chain.time() + DAY * 365 * 4, {"from": receiver}
+        )
+
+
+@pytest.fixture(params=[ZERO_ADDRESS, ETH_ADDRESS])
+def delegation_data(alice, bob, charlie, chain, dave, request):
+    # [user, recipient, gauge, percentage, cancel_time, unlock_time]
+    return [
+        [charlie, request.param, dave, 1_000, chain.time() + DAY * 7, chain.time() + DAY * 31],
+        [bob, request.param, dave, 5_000, chain.time() + DAY * 14, chain.time() + DAY * 180],
+        [alice, request.param, dave, 10_000, chain.time() + DAY * 31, chain.time() + DAY * 365],
+    ]
+
+
+def test_receive_multiple_delegations(boost_delegation, voting_escrow, delegation_data, dave):
+    adjusted_vecrv_balance = 0
+    for data in delegation_data:
+        boost_delegation.delegate_boost(*data, {"from": data[0]})
+        adjusted_vecrv_balance += voting_escrow.balanceOf(data[0]) * data[3] // 10_000
+
+    assert math.isclose(
+        boost_delegation.get_adjusted_vecrv_balance(dave, delegation_data[0][1]),
+        adjusted_vecrv_balance,
+        rel_tol=0.001,
+    )
+
+    for idx, data in enumerate(delegation_data):
+        # since we aren't removing it'll be ordered to same
+        delegation_data = boost_delegation.get_delegation_data(data[2], data[1], idx)
+        assert delegation_data == [data[0]] + data[3:]
+
+
+@pytest.mark.parametrize("num_expired", [1, 2, 3])
+def test_receive_multiple_delegations_expire(
+    boost_delegation, chain, delegation_data, dave, num_expired, voting_escrow
+):
+    expiration_times = [DAY * i for i in [31, 180, 365]]
+
+    for data in delegation_data:
+        boost_delegation.delegate_boost(*data, {"from": data[0]})
+
+    chain.mine(timedelta=expiration_times[num_expired - 1])
+
+    adjusted_vecrv_balance = 0
+    for idx, data in enumerate(delegation_data):
+        multiplier = 0 if idx < num_expired else 1
+        adjusted_vecrv_balance += multiplier * voting_escrow.balanceOf(data[0]) * data[3] // 10_000
+
+    assert (
+        boost_delegation.get_adjusted_vecrv_balance(dave, delegation_data[0][1])
+        == adjusted_vecrv_balance
+    )
+
+    boost_delegation.update_delegation_records(dave, delegation_data[0][1], {"from": dave})
+
+    for idx, data in enumerate(delegation_data[num_expired:][::-1]):
+        on_chain_delegation_data = boost_delegation.get_delegation_data(data[2], data[1], idx)
+        assert on_chain_delegation_data == [data[0]] + data[3:]

--- a/tests/boost_delegation/test_set_operator.py
+++ b/tests/boost_delegation/test_set_operator.py
@@ -1,0 +1,14 @@
+from brownie import ZERO_ADDRESS
+
+
+def test_set_operator_to_someone_else(alice, bob, boost_delegation):
+    boost_delegation.set_operator(bob, {"from": alice})
+
+    assert boost_delegation.operator_of(alice) == bob
+
+
+def test_unset_operator(alice, bob, boost_delegation):
+    boost_delegation.set_operator(bob, {"from": alice})
+    boost_delegation.set_operator(ZERO_ADDRESS, {"from": alice})
+
+    assert boost_delegation.operator_of(alice) == ZERO_ADDRESS

--- a/tests/boost_delegation/test_state.py
+++ b/tests/boost_delegation/test_state.py
@@ -1,0 +1,162 @@
+import copy
+from collections import defaultdict
+from typing import DefaultDict, Dict, List, Tuple
+
+import brownie
+from brownie import ZERO_ADDRESS, Contract, chain, convert
+from dataclassy import dataclass
+
+
+@dataclass(iter=True, slots=True)
+class Data:
+    account: str = ZERO_ADDRESS
+    percentage: int = 0
+    cancel_time: int = 0
+    expire_time: int = 0
+
+    def __int__(self):
+        return (
+            (convert.to_uint(self.account) << 96)
+            + (self.percentage << 80)
+            + (self.cancel_time << 40)
+            + self.expire_time
+        )
+
+
+class BoostDelegationLogic:
+    def __init__(self, voting_escrow: Contract) -> None:
+        self.delegation_count: DefaultDict[str, int] = defaultdict(lambda: 0)
+        self.operator_of: DefaultDict[str, str] = defaultdict(lambda: ZERO_ADDRESS)
+
+        self._delegation_data: DefaultDict[str, DefaultDict[str, List[Data]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        self._delegated_to: DefaultDict[str, DefaultDict[str, Data]] = defaultdict(
+            lambda: defaultdict(lambda: Data())
+        )
+
+        self.is_killed: bool = False
+
+        self.voting_escrow = voting_escrow
+
+    def get_delegated_to(self, delegator: str, gauge: str) -> Tuple[str, int, int, int]:
+        return tuple(self._delegated_to[delegator][gauge])
+
+    def get_delegation_data(
+        self, receiver: str, gauge: str, index: int
+    ) -> Tuple[str, int, int, int]:
+        if len(data := self._delegation_data[receiver][gauge]) > index:
+            return tuple(data[index])
+        return tuple(Data())
+
+    def set_operator(self, operator: str, tx_params: Dict) -> bool:
+        self.operator_of[tx_params["from"]] = operator
+        return True
+
+    def _delete_delegation_data(self, delegator: str, gauge: str, data: Data) -> bool:
+        self._delegated_to[delegator][gauge] = Data()
+        self.delegation_count[delegator] -= 1
+        assert self.delegation_count[delegator] >= 0
+
+        # delegation data has the delegator not the receiver
+        receiver = data.account
+        delegation_data = Data(delegator, *(tuple(data)[1:]))
+        index = self._delegation_data[receiver][gauge].index(delegation_data)
+
+        assert 0 <= index < 10
+        self._delegation_data[receiver][gauge].remove(delegation_data)
+        assert 0 <= len(self._delegation_data[receiver][gauge]) < 10
+
+    def delegate_boost(
+        self,
+        delegator: str,
+        gauge: str,
+        receiver: str,
+        pct: int,
+        cancel_time: int,
+        expire_time: int,
+        tx_params: Dict,
+    ):
+        assert not self.is_killed
+        assert tx_params["from"] in [delegator, self.operator_of[delegator]]
+
+        assert delegator != receiver
+        assert 100 <= pct <= 10_000
+        assert chain.time() < expire_time < 2 ** 40
+        assert cancel_time <= expire_time
+
+        assert self.voting_escrow.balanceOf(delegator) >= 2500 * 10 ** 18
+
+        # check for existing delegation
+        if int(data := self._delegated_to[delegator][gauge]) != 0:
+            # check that existing delegation has expired
+            assert data.expire_time <= chain.time()
+            self._delete_delegation_data(delegator, gauge, data)
+
+        if gauge == ZERO_ADDRESS:
+            # trying to delegate globally without first clearing records
+            assert self.delegation_count[delegator] == 0
+        else:
+            # Cannot delegate per-gauge while global delegation is active
+            assert int(self._delegated_to[delegator][ZERO_ADDRESS]) == 0
+
+        data = Data(receiver, pct, cancel_time, expire_time)
+        self._delegated_to[delegator][gauge] = data
+        self.delegation_count[delegator] += 1
+
+        delegation_data = copy.deepcopy(data)
+        delegation_data.account = delegator
+        self._delegation_data[receiver][gauge].append(delegation_data)
+        assert len(self._delegation_data[receiver][gauge]) <= 10
+
+    def cancel_delegation(self, delegator: str, gauge: str, tx_params: Dict):
+        msg_sender = tx_params["from"]
+
+        data = self._delegated_to[delegator][gauge]
+        assert int(data) != 0
+
+        receiver = data.account
+        if msg_sender not in [receiver, self.operator_of[receiver]]:
+            assert msg_sender in [delegator, self.operator_of[delegator]]
+            assert data.cancel_time <= chain.time()
+
+        self._delete_delegation_data(delegator, gauge, data)
+
+    def update_delegation_records(self, user: str, gauge: str):
+        for data in self._delegation_data[user][gauge]:
+            delegator = data.account
+            if data.expire_time <= chain.time():
+                self._delete_delegation_data(delegator, gauge, self._delegated_to[delegator][gauge])
+
+    def get_adjusted_vecrv_balance(self, user: str, gauge: str, block_identifier: int):
+        with brownie.multicall(block_identifier=block_identifier):
+            vecrv_balance = self.voting_escrow.balanceOf(user)
+
+        if self.is_killed:
+            return vecrv_balance
+
+        if (delegation_count := self.delegation_count[user]) != 0:
+            is_global = False
+            if delegation_count == 1:
+                data = self._delegated_to[user][ZERO_ADDRESS]
+                if data.expire_time > chain.time():
+                    vecrv_balance = vecrv_balance * (10_000 - data.percentage) // 10_000
+                    is_global = True
+
+            if not is_global:
+                data = self._delegated_to[user][gauge]
+                if data.expire_time > chain.time():
+                    vecrv_balance = vecrv_balance * (10_000 - data.percentage) // 10_000
+
+        for target in set([gauge, ZERO_ADDRESS]):
+            for data in self._delegation_data[user][target]:
+                if data.expire_time > chain.time():
+                    delegator = data.account
+                    with brownie.multicall(block_identifier=block_identifier):
+                        delegator_balance = self.voting_escrow.balanceOf(delegator)
+                    vecrv_balance += delegator_balance * (10_000 - data.percentage) // 10_000
+
+        return vecrv_balance
+
+    def set_is_killed(self, killed: bool):
+        self.is_killed = killed

--- a/tests/boost_delegation/test_update_delegation_records.py
+++ b/tests/boost_delegation/test_update_delegation_records.py
@@ -1,0 +1,76 @@
+import pytest
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
+
+DAY = 86400
+
+
+@pytest.fixture(params=[ZERO_ADDRESS, ETH_ADDRESS], ids=["GlobalDelegation", "GaugeDelegation"])
+def delegated_gauge(request):
+    return request.param
+
+
+@pytest.fixture(autouse=True)
+def setup(alice, chain, bob, boost_delegation, lock_crv, delegated_gauge):
+    boost_delegation.delegate_boost(
+        alice,
+        delegated_gauge,
+        bob,
+        10_000,
+        chain.time() + DAY * 30,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+
+
+def test_update_clears_expired_delegations(alice, bob, boost_delegation, chain, delegated_gauge):
+    chain.sleep(DAY * 366)
+
+    boost_delegation.update_delegation_records(bob, delegated_gauge, {"from": bob})
+
+    assert boost_delegation.delegation_count(alice) == 0
+    assert boost_delegation.get_delegated_to(alice, delegated_gauge) == [ZERO_ADDRESS, 0, 0, 0]
+    assert boost_delegation.get_delegation_data(bob, delegated_gauge, 0) == [ZERO_ADDRESS, 0, 0, 0]
+
+
+def test_update_clears_only_expired_delegations(
+    alice, bob, charlie, chain, boost_delegation, delegated_gauge
+):
+
+    chain.sleep(DAY * 366)
+
+    other_gauge = ZERO_ADDRESS if delegated_gauge == ZERO_ADDRESS else charlie
+
+    boost_delegation.delegate_boost(
+        alice,
+        other_gauge,
+        bob,
+        10_000,
+        chain.time() + DAY * 30,
+        chain.time() + DAY * 365,
+        {"from": alice},
+    )
+
+    boost_delegation.update_delegation_records(bob, delegated_gauge, {"from": charlie})
+
+    assert boost_delegation.get_delegated_to(alice, other_gauge)[:2] == [bob, 10_000]
+    assert boost_delegation.get_delegation_data(bob, other_gauge, 0)[:2] == [alice, 10_000]
+
+    if other_gauge == ZERO_ADDRESS:
+        # ZERO_ADDRESS -> ZERO_ADDRESS
+        return
+
+    assert boost_delegation.delegation_count(alice) == 1
+    assert boost_delegation.get_delegated_to(alice, delegated_gauge) == [ZERO_ADDRESS, 0, 0, 0]
+    assert boost_delegation.get_delegation_data(bob, delegated_gauge, 0) == [ZERO_ADDRESS, 0, 0, 0]
+
+
+def test_update_is_a_noop_before_expiration(
+    alice, bob, charlie, chain, boost_delegation, delegated_gauge
+):
+    chain.sleep(DAY * 183)
+
+    boost_delegation.update_delegation_records(bob, delegated_gauge, {"from": charlie})
+
+    assert boost_delegation.delegation_count(alice) == 1
+    assert boost_delegation.get_delegated_to(alice, delegated_gauge)[:2] == [bob, 10_000]
+    assert boost_delegation.get_delegation_data(bob, delegated_gauge, 0)[:2] == [alice, 10_000]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,19 +20,19 @@ def pytest_addoption(parser):
     parser.addoption(
         "--plain-pool-size",
         action="store",
-        default="2,3,4",
+        default="2",
         help="comma-separated list of plain pool sizes to test against",
     )
     parser.addoption(
         "--plain-pool-type",
         action="store",
-        default="basic,eth,optimized,rebase",
+        default="basic",
         help="comma-separated list of plain pool sizes to test against",
     )
     parser.addoption(
         "--return-type",
         action="store",
-        default="revert,False,None",
+        default="revert",
         help="comma-separated list of ERC20 token return types to test against",
     )
     parser.addoption(

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -146,3 +146,12 @@ def owner_proxy(alice, OwnerProxy):
 def gauge(alice, factory, swap, LiquidityGauge, set_gauge_implementation):
     tx = factory.deploy_gauge(swap, {"from": alice})
     return LiquidityGauge.at(tx.return_value)
+
+
+@pytest.fixture(scope="session")
+def boost_delegation(alice, BoostDelegation, voting_escrow):
+    source = BoostDelegation._build["source"]
+    source = source.replace("0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2", voting_escrow.address)
+
+    NewBoostDelegation = compile_source(source).Vyper
+    return NewBoostDelegation.deploy({"from": alice})

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -154,4 +154,4 @@ def boost_delegation(alice, BoostDelegation, voting_escrow):
     source = source.replace("0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2", voting_escrow.address)
 
     NewBoostDelegation = compile_source(source).Vyper
-    return NewBoostDelegation.deploy({"from": alice})
+    return NewBoostDelegation.deploy(alice, {"from": alice})

--- a/tests/fixtures/functions.py
+++ b/tests/fixtures/functions.py
@@ -71,3 +71,10 @@ def approve_bob(bob, coins, swap):
 @pytest.fixture
 def add_initial_liquidity(alice, approve_alice, mint_alice, initial_amounts, swap, eth_amount):
     swap.add_liquidity(initial_amounts, 0, {"from": alice, "value": eth_amount(initial_amounts[0])})
+
+
+@pytest.fixture
+def lock_crv(alice, crv, voting_escrow, chain):
+    amount = crv.balanceOf(alice) // 2
+    crv.approve(voting_escrow, amount, {"from": alice})
+    voting_escrow.create_lock(amount, chain.time() + 86400 * 365 * 4, {"from": alice})


### PR DESCRIPTION
### What I did
Initial implementation of delegated boost.

Delegation for all gauges is handled via a single contract, `BoostDelegation`. When determining boost, gauges call to `BoostDelegation.get_adjusted_vecrv_balance` instead of `VotingEscrow.balanceOf`, which returns an adjusted veCRV balance after delegation.

When delegating, a user declares:
  - which gauge they are delegating for (or can be global for all gauges)
  - the address they are delegating to
  - the % of veCRV being delegated
  - a timestamp after which the delegation can be canceled
  - a timestamp when the delegation expires

An operator may also be declared, who is capable of delegating on behalf of another user.