### PR TITLE
Quality of life improvement in gauge extension

### DIFF
--- a/contracts/implementations/templates/MetaBalances.vy
+++ b/contracts/implementations/templates/MetaBalances.vy
@@ -29,7 +29,7 @@ interface Gauge:
     def withdraw(_value: uint256): nonpayable
 
 interface GaugeExtension:
-    def initialize(): nonpayable
+    def initialize(_base_gauge: address): nonpayable
     def checkpoint_rewards(_addr: address): nonpayable
 
 interface Factory:
@@ -182,7 +182,7 @@ def initialize(
     self.symbol = concat(_symbol, "3CRV-f")
 
     receiver: address = create_forwarder_to(GAUGE_EXTENSION_IMPL)
-    GaugeExtension(receiver).initialize()
+    GaugeExtension(receiver).initialize(BASE_GAUGE)
     
     self.rewards_receiver = receiver
 

--- a/contracts/implementations/templates/MetaStandard.vy
+++ b/contracts/implementations/templates/MetaStandard.vy
@@ -28,7 +28,7 @@ interface Gauge:
     def withdraw(_value: uint256): nonpayable
 
 interface GaugeExtension:
-    def initialize(): nonpayable
+    def initialize(_base_gauge: address): nonpayable
     def checkpoint_rewards(_addr: address): nonpayable
 
 interface Factory:
@@ -181,7 +181,7 @@ def initialize(
     self.symbol = concat(_symbol, "3CRV-f")
 
     receiver: address = create_forwarder_to(GAUGE_EXTENSION_IMPL)
-    GaugeExtension(receiver).initialize()
+    GaugeExtension(receiver).initialize(BASE_GAUGE)
     
     self.rewards_receiver = receiver
 

--- a/scripts/deploy_templates.py
+++ b/scripts/deploy_templates.py
@@ -32,13 +32,13 @@ BASE_COINS = [
     ZERO_ADDRESS,
 ]
 BASE_LP_TOKEN = ZERO_ADDRESS
-GAUGE_EXTENSION_IMPL = None  # change this if one is already deployed
+# only one gauge extension per factory deployment is necessary
+GAUGE_EXTENSION_IMPL = None  # change this if one is already deployed for the current factory
 
 
-def deploy_gauge_extension(_base_gauge: str, _factory: str):
+def deploy_gauge_extension(_factory: str):
     source = GaugeExtension._build["source"]
-    for addr in [_base_gauge, _factory]:
-        source = source.replace(ZERO_ADDRESS, addr, 1)
+    source = source.replace(ZERO_ADDRESS, _factory, 1)
 
     MetaGaugeExtension = compile_source(source).Vyper
     deployment = MetaGaugeExtension.deploy({"from": DEPLOYER})
@@ -53,13 +53,13 @@ def deploy_meta_implementation(_implementation_source: str):
     global GAUGE_EXTENSION_IMPL
 
     if GAUGE_EXTENSION_IMPL is None:
-        GAUGE_EXTENSION_IMPL = deploy_gauge_extension(BASE_GAUGE, FACTORY).address
+        GAUGE_EXTENSION_IMPL = deploy_gauge_extension(FACTORY).address
 
     source = _implementation_source
-    for addr in [BASE_POOL, BASE_LP_TOKEN, BASE_GAUGE, GAUGE_EXTENSION_IMPL]:
-        source = source.replace(f"= {ZERO_ADDRESS}", f"= {addr}", 1)
     source = source.replace("69", str(len(BASE_COINS)), 1)
     source = source.replace(f"[{', '.join([ZERO_ADDRESS] * 69)}]", f"[{', '.join(BASE_COINS)}]")
+    for addr in [BASE_POOL, BASE_LP_TOKEN, BASE_GAUGE, GAUGE_EXTENSION_IMPL]:
+        source = source.replace(f"= {ZERO_ADDRESS}", f"= {addr}", 1)
 
     META = compile_source(source).Vyper
     meta = META.deploy({"from": DEPLOYER})

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -332,10 +332,9 @@ def gauge_implementation(
 
 
 @pytest.fixture(scope="session")
-def sidechain_meta_gauge(alice, GaugeExtension, factory, base_gauge):
+def sidechain_meta_gauge(alice, GaugeExtension, factory):
     source = GaugeExtension._build["source"]
-    for contra in [base_gauge, factory]:
-        source = source.replace("0x0000000000000000000000000000000000000000", contra.address, 1)
+    source = source.replace("0x0000000000000000000000000000000000000000", factory.address, 1)
     return compile_source(source).Vyper.deploy({"from": alice})
 
 


### PR DESCRIPTION
The gauge extension no longer has the base gauge as a constant, instead it is supplied on proxy initialization.
This is a quality of life improvement, to reduce the amount of deployments, and complexity overhead.

This also means that only one gauge extension implementation needs to be deployed per factory deployment.

Changes:
- Gauge extension initialization (function as well as metapool calls to initialize)
- Template deployment script

Essentially if the tests pass this is good to go, since all that's been modified is the initialization call of proxies