### PR TITLE
Check that pool exists in registry

### DIFF
--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -724,6 +724,7 @@ def add_base_pool(
 
     registry: address = AddressProvider(ADDRESS_PROVIDER).get_registry()
     n_coins: uint256 = Registry(registry).get_n_coins(_base_pool)
+    assert n_coins > 0  # dev: pool not in registry
 
     # add pool to pool_list
     length: uint256 = self.base_pool_count

--- a/contracts/FactorySidechains.vy
+++ b/contracts/FactorySidechains.vy
@@ -719,6 +719,7 @@ def add_base_pool(
 
     registry: address = AddressProvider(ADDRESS_PROVIDER).get_registry()
     n_coins: uint256 = Registry(registry).get_n_coins(_base_pool)
+    assert n_coins > 0  # dev: pool not in registry
 
     # add pool to pool_list
     length: uint256 = self.base_pool_count


### PR DESCRIPTION
If a base pool is added but not included in the registry, it creates issues later when adding metapools.