### PR TITLE
fix: only indicate underlying on metapools

### DIFF
--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -436,7 +436,7 @@ def get_coin_indices(
         # the first time we find a match, set `found_market` to True
         found_market = True
 
-    return i, j, True
+    return i, j, base_pool != ZERO_ADDRESS
 
 
 @view

--- a/contracts/FactorySidechains.vy
+++ b/contracts/FactorySidechains.vy
@@ -432,7 +432,7 @@ def get_coin_indices(
         # the first time we find a match, set `found_market` to True
         found_market = True
 
-    return i, j, True
+    return i, j, base_pool != ZERO_ADDRESS
 
 
 @view


### PR DESCRIPTION
When querying `get_coin_indices`, only return `True` for `is_underlying` if the pool being queries is a metapool.