### PR TITLE
Feat/gauge manager proxy

### DIFF
--- a/contracts/ManagerProxy.vy
+++ b/contracts/ManagerProxy.vy
@@ -1,0 +1,79 @@
+# @version 0.3.3
+"""
+@notice Gauge Manager Proxy
+@author CurveFi
+"""
+
+
+interface Factory:
+    def admin() -> address: view
+    def deploy_gauge(_pool: address) -> address: nonpayable
+
+interface OwnerProxy:
+    def add_reward(_gauge: address, _reward_token: address, _distributor: address): nonpayable
+    def ownership_admin() -> address: view
+    def set_reward_distributor(_gauge: address, _reward_token: address, _distributor: address): nonpayable
+
+
+event SetManager:
+    _manager: indexed(address)
+
+event SetGaugeManager:
+    _gauge: indexed(address)
+    _gauge_manager: indexed(address)
+
+
+FACTORY: immutable(address)
+OWNER_PROXY: immutable(address)
+
+
+gauge_manager: public(HashMap[address, address])
+manager: public(address)
+
+
+@external
+def __init__(_factory: address):
+    FACTORY = _factory
+    OWNER_PROXY = Factory(_factory).admin()
+
+    self.manager = msg.sender
+    log SetManager(msg.sender)
+
+
+@external
+def add_reward(_gauge: address, _reward_token: address, _distributor: address):
+    assert msg.sender == self.gauge_manager[_gauge]
+
+    OwnerProxy(OWNER_PROXY).add_reward(_gauge, _reward_token, _distributor)
+
+
+@external
+def set_reward_distributor(_gauge: address, _reward_token: address, _distributor: address):
+    assert msg.sender == self.gauge_manager[_gauge]
+
+    OwnerProxy(OWNER_PROXY).set_reward_distributor(_gauge, _reward_token, _distributor)
+
+
+@external
+def deploy_gauge(_pool: address, _gauge_manager: address = msg.sender) -> address:
+    gauge: address = Factory(FACTORY).deploy_gauge(_pool)
+
+    self.gauge_manager[gauge] = _gauge_manager
+    log SetGaugeManager(gauge, _gauge_manager)
+    return gauge
+
+
+@external
+def set_gauge_manager(_gauge: address, _gauge_manager: address):
+    assert msg.sender in [self.manager, OwnerProxy(OWNER_PROXY).ownership_admin()]
+
+    self.gauge_manager[_gauge] = _gauge_manager
+    log SetGaugeManager(_gauge, _gauge_manager)
+
+
+@external
+def set_manager(_manager: address):
+    assert msg.sender in [self.manager, OwnerProxy(OWNER_PROXY).ownership_admin()]
+
+    self.manager = _manager
+    log SetManager(_manager)

--- a/contracts/ManagerProxy.vy
+++ b/contracts/ManagerProxy.vy
@@ -32,12 +32,12 @@ manager: public(address)
 
 
 @external
-def __init__(_factory: address):
+def __init__(_factory: address, _manager: address):
     FACTORY = _factory
     OWNER_PROXY = Factory(_factory).admin()
 
-    self.manager = msg.sender
-    log SetManager(msg.sender)
+    self.manager = _manager
+    log SetManager(_manager)
 
 
 @external

--- a/contracts/ManagerProxy.vy
+++ b/contracts/ManagerProxy.vy
@@ -42,20 +42,37 @@ def __init__(_factory: address):
 
 @external
 def add_reward(_gauge: address, _reward_token: address, _distributor: address):
-    assert msg.sender == self.gauge_manager[_gauge]
+    """
+    @notice Add a reward to a gauge
+    @param _gauge The gauge the reward will be added to
+    @param _reward_token The token to be added as a reward (should be ERC20-compliant)
+    @param _distributor The account which will top-up, and distribute the rewards.
+    """
+    assert msg.sender in [self.gauge_manager[_gauge], self.manager]
 
     OwnerProxy(OWNER_PROXY).add_reward(_gauge, _reward_token, _distributor)
 
 
 @external
 def set_reward_distributor(_gauge: address, _reward_token: address, _distributor: address):
-    assert msg.sender == self.gauge_manager[_gauge]
+    """
+    @notice Set the reward distributor for a gauge
+    @param _gauge The gauge to update
+    @param _reward_token The reward token for which the distributor will be changed
+    @param _distributor The new distributor for the reward token.
+    """
+    assert msg.sender in [self.gauge_manager[_gauge], self.manager]
 
     OwnerProxy(OWNER_PROXY).set_reward_distributor(_gauge, _reward_token, _distributor)
 
 
 @external
 def deploy_gauge(_pool: address, _gauge_manager: address = msg.sender) -> address:
+    """
+    @notice Deploy a gauge, and set _gauge_manager as the manager
+    @param _pool The pool to deploy a gauge for
+    @param _gauge_manager The account to which will manage rewards for the gauge
+    """
     gauge: address = Factory(FACTORY).deploy_gauge(_pool)
 
     self.gauge_manager[gauge] = _gauge_manager
@@ -65,7 +82,16 @@ def deploy_gauge(_pool: address, _gauge_manager: address = msg.sender) -> addres
 
 @external
 def set_gauge_manager(_gauge: address, _gauge_manager: address):
-    assert msg.sender in [self.manager, OwnerProxy(OWNER_PROXY).ownership_admin()]
+    """
+    @notice Change the gauge manager for a gauge
+    @dev The manager of this contract, or the ownership admin can outright modify gauge
+        managership. A gauge manager can also transfer managership to a new manager via this
+        method, but only for the gauge which they are the manager of.
+    @param _gauge The gauge to change the managership of
+    @param _gauge_manager The account to set as the new manager of the gauge.
+    """
+    if msg.sender not in [self.manager, OwnerProxy(OWNER_PROXY).ownership_admin()]:
+        assert msg.sender == self.gauge_manager[_gauge]
 
     self.gauge_manager[_gauge] = _gauge_manager
     log SetGaugeManager(_gauge, _gauge_manager)
@@ -73,7 +99,23 @@ def set_gauge_manager(_gauge: address, _gauge_manager: address):
 
 @external
 def set_manager(_manager: address):
+    """
+    @notice Set the manager of this contract
+    @param _manager The account to set as the manager
+    """
     assert msg.sender in [self.manager, OwnerProxy(OWNER_PROXY).ownership_admin()]
 
     self.manager = _manager
     log SetManager(_manager)
+
+
+@pure
+@external
+def factory() -> address:
+    return FACTORY
+
+
+@pure
+@external
+def owner_proxy() -> address:
+    return OWNER_PROXY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,11 +104,11 @@ def pytest_collection_modifyitems(config, items):
         path_parts = path.parts[1:-1]
         try:
             params = item.callspec.params
-            pool_size = params["plain_pool_size"]
-            pool_type = params["pool_type"]
-            return_type = params["return_type"]
-            decimals = params["decimals"]
-            meta_implementation_idx = params["meta_implementation_idx"]
+            pool_size = params.get("plain_pool_size", 2)
+            pool_type = params.get("pool_type", 2)
+            return_type = params.get("return_type", 0)
+            decimals = params.get("decimals", 18)
+            meta_implementation_idx = params.get("meta_implementation_idx", 0)
         except Exception:
             if path_parts == ():
                 if pool_type != 2:
@@ -168,7 +168,7 @@ def pytest_collection_modifyitems(config, items):
             continue
 
         if "test_factory.py" not in path.parts and len(path.parts) == 2:
-            if not (pool_type == 2 and pool_size == 2):
+            if pool_type != 2 or pool_size != 2:
                 items.remove(item)
                 continue
 

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -423,7 +423,7 @@ def swap(
 
 @pytest.fixture(scope="module")
 def owner_proxy(alice, OwnerProxy):
-    return OwnerProxy.deploy(alice, alice, alice, {"from": alice})
+    return OwnerProxy.deploy(alice, alice, alice, alice, {"from": alice})
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_gauge_manager_proxy.py
+++ b/tests/test_gauge_manager_proxy.py
@@ -1,0 +1,56 @@
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module")
+def manager_proxy(alice, factory, owner_proxy, ManagerProxy):
+    factory.commit_transfer_ownership(owner_proxy, {"from": alice})
+    owner_proxy.accept_transfer_ownership(factory, {"from": alice})
+
+    return ManagerProxy.deploy(factory, alice, {"from": alice})
+
+
+def test_add_reward(alice, manager_proxy, gauge, coin_reward):
+    assert gauge.reward_count() == 0
+    manager_proxy.add_reward(gauge, coin_reward, alice, {"from": alice})
+
+    assert gauge.reward_tokens(0) == coin_reward
+    assert gauge.reward_data(coin_reward)["distributor"] == alice
+
+
+def test_set_reward_distributor(alice, bob, manager_proxy, gauge, coin_reward):
+    assert gauge.reward_count() == 0
+    manager_proxy.add_reward(gauge, coin_reward, alice, {"from": alice})
+
+    manager_proxy.set_reward_distributor(gauge, coin_reward, bob, {"from": alice})
+    assert gauge.reward_data(coin_reward)["distributor"] == bob
+
+
+def test_set_gauge_manager(alice, bob, manager_proxy, gauge):
+    # alice is both the ownership_admin and the manager
+    tx = manager_proxy.set_gauge_manager(gauge, bob, {"from": alice})
+    assert manager_proxy.gauge_manager(gauge) == bob
+    assert tx.events["SetGaugeManager"].values() == [gauge, bob]
+
+    # bob is the gague manager and can transfer managership
+    manager_proxy.set_gauge_manager(gauge, alice, {"from": bob})
+    assert manager_proxy.gauge_manager(gauge) == alice
+
+    # bob is no longer the gauge manager
+    with brownie.reverts():
+        manager_proxy.set_gauge_manager(gauge, alice, {"from": bob})
+
+
+def test_set_manager(alice, bob, manager_proxy):
+    # alice is both the manager and the ownership_admin
+    manager_proxy.set_manager(bob, {"from": alice})
+    assert manager_proxy.manager() == bob
+
+    # now alice is only the ownership_admin
+    manager_proxy.set_manager(alice, {"from": alice})
+    assert manager_proxy.manager() == alice
+
+    with brownie.reverts():
+        # bob is not the manager anymore
+        manager_proxy.set_manager(alice, {"from": bob})
+    assert manager_proxy.manager() == alice

--- a/tests/test_gauge_manager_proxy.py
+++ b/tests/test_gauge_manager_proxy.py
@@ -1,13 +1,17 @@
 import brownie
 import pytest
 
+from brownie import ZERO_ADDRESS
+
 
 @pytest.fixture(scope="module")
 def manager_proxy(alice, factory, owner_proxy, ManagerProxy):
     factory.commit_transfer_ownership(owner_proxy, {"from": alice})
     owner_proxy.accept_transfer_ownership(factory, {"from": alice})
 
-    return ManagerProxy.deploy(factory, alice, {"from": alice})
+    proxy = ManagerProxy.deploy(factory, alice, {"from": alice})
+    owner_proxy.set_gauge_manager(proxy, {"from": alice})
+    return proxy
 
 
 def test_add_reward(alice, manager_proxy, gauge, coin_reward):
@@ -24,6 +28,23 @@ def test_set_reward_distributor(alice, bob, manager_proxy, gauge, coin_reward):
 
     manager_proxy.set_reward_distributor(gauge, coin_reward, bob, {"from": alice})
     assert gauge.reward_data(coin_reward)["distributor"] == bob
+
+def test_deploy_gauge(alice, manager_proxy, factory, coin_a, coin_b):
+    pool = factory.deploy_plain_pool(
+        "foo",
+        "foo",
+        [coin_a, coin_b, ZERO_ADDRESS, ZERO_ADDRESS],
+        200,
+        .0004 * 10 ** 10,
+        0,
+        0,
+        {"from": alice}
+    ).return_value
+
+    gauge = manager_proxy.deploy_gauge(pool, {"from": alice}).return_value
+
+    assert manager_proxy.gauge_manager(gauge) == alice
+    assert factory.get_gauge(pool) == gauge
 
 
 def test_set_gauge_manager(alice, bob, manager_proxy, gauge):


### PR DESCRIPTION
Extension contract enabling users to manage the rewards of their own gauges without requiring a DAO vote for adding/removing rewards.

Also enables trustless setups, where a contract is the gauge manager.